### PR TITLE
fix: prevent exceptions in custom hooks code

### DIFF
--- a/src/hooks/custom_user_agent.ts
+++ b/src/hooks/custom_user_agent.ts
@@ -1,11 +1,20 @@
-import { BeforeRequestContext, BeforeRequestHook, Awaitable } from './types';
-
+import { SDK_METADATA } from "../lib/config";
+import { BeforeRequestContext, BeforeRequestHook, Awaitable } from "./types";
 
 export class CustomUserAgentHook implements BeforeRequestHook {
-    beforeRequest(_: BeforeRequestContext, request: Request): Awaitable<Request> {
-        const userAgent = request.headers.get('user-agent') as string;
-        const version = userAgent.split(' ')[1];
-        request.headers.set('user-agent', `mistral-client-typescript/${version}`);
-        return request;
+  beforeRequest(_: BeforeRequestContext, request: Request): Awaitable<Request> {
+    const version = SDK_METADATA.sdkVersion;
+    const ua = `mistral-client-typescript/${version}`;
+
+    request.headers.set("user-agent", ua);
+
+    // In Chrome, the line above may silently fail. If the header was not set
+    // we fallback to setting an alternate header.
+    // Chromium bug: https://issues.chromium.org/issues/40450316
+    if (!request.headers.get("user-agent")) {
+      request.headers.set("x-mistral-user-agent", ua);
     }
+
+    return request;
+  }
 }

--- a/src/hooks/deprecation_warning.ts
+++ b/src/hooks/deprecation_warning.ts
@@ -6,7 +6,7 @@ const HEADER_MODEL_DEPRECATION_TIMESTAMP = "x-model-deprecation-timestamp";
 export class DeprecationWarningHook implements AfterSuccessHook {
     afterSuccess(_: AfterSuccessContext, response: Response): Awaitable<Response> {
         if (response.headers.has(HEADER_MODEL_DEPRECATION_TIMESTAMP)) {
-            response.json().then((body) => {
+            response.clone().json().then((body) => {
                 const model = body.model;
                 console.warn(
                     `WARNING: The model ${model} is deprecated and will be removed on ${response.headers.get(HEADER_MODEL_DEPRECATION_TIMESTAMP)}. Please refer to https://docs.mistral.ai/getting-started/models/#api-versioning for more information.`


### PR DESCRIPTION
This PR contains two sets of fixes for the custom hooks in the SDK. There are a couple of latent bugs in these, one of which prevents using the SDK in Chrome.