### PR TITLE
Fix streaming response with empty content

### DIFF
--- a/.speakeasy/gen.lock
+++ b/.speakeasy/gen.lock
@@ -1,12 +1,12 @@
 lockVersion: 2.0.0
 id: 81b65c50-f2e3-40a3-bd65-346524007b3d
 management:
-  docChecksum: c19f5a86b8045af32a46604ee5478061
+  docChecksum: 87135817a5a746d7466c41070e5f581e
   docVersion: 0.0.2
-  speakeasyVersion: 1.372.0
+  speakeasyVersion: 1.373.1
   generationVersion: 2.399.0
-  releaseVersion: 1.1.2
-  configChecksum: 73da950b6151099c2d5a87da13ba3360
+  releaseVersion: 1.1.3
+  configChecksum: 82af20b5faaac173abb6d630c7f4194f
   repoURL: https://github.com/mistralai/client-ts.git
   installationURL: https://github.com/mistralai/client-ts
   published: true

--- a/.speakeasy/gen.yaml
+++ b/.speakeasy/gen.yaml
@@ -15,7 +15,7 @@ generation:
   auth:
     oAuth2ClientCredentialsEnabled: true
 typescript:
-  version: 1.1.2
+  version: 1.1.3
   additionalDependencies:
     dependencies: {}
     devDependencies: {}

--- a/.speakeasy/workflow.lock
+++ b/.speakeasy/workflow.lock
@@ -1,41 +1,41 @@
-speakeasyVersion: 1.372.0
+speakeasyVersion: 1.373.1
 sources:
     mistral-azure-source:
         sourceNamespace: mistral-openapi-azure
-        sourceRevisionDigest: sha256:bc53dba5935490a409045de3c39ccf9e90243a289656dd538a542990aa376cca
-        sourceBlobDigest: sha256:4173c3be19775dd2bdd4ce28bb9ae6655650df75f2b689a44c3362d418d69d49
+        sourceRevisionDigest: sha256:becb324b11dfc5155aa0cc420ca312d0af5aecfcbad22fe90066a09561ae4e6a
+        sourceBlobDigest: sha256:84928a6297c3a838dce719ffa3da1e221cba968ce4a6c74d5c3bb41bf86a7e5d
         tags:
             - latest
     mistral-google-cloud-source:
         sourceNamespace: mistral-openapi-google-cloud
-        sourceRevisionDigest: sha256:ab52d75474e071db240ed9a5367dc6374867b5c9306d478dcfdf8f7b7d08607f
-        sourceBlobDigest: sha256:d5f9c665861d7fedd5093567d13e1f7f6a12b82137fbbecda4708007b15030ba
+        sourceRevisionDigest: sha256:7fee22ae1a434b8919112c7feae87af7f1378952fcc6bde081deb55f65e5bfc2
+        sourceBlobDigest: sha256:a4c011f461c73809a7d6cf1c9823d3c51d5050895aad246287ff14ac971efb8c
         tags:
             - latest
     mistral-openapi:
         sourceNamespace: mistral-openapi
-        sourceRevisionDigest: sha256:e4d5f5fe40e7f1141006ba40c1d85b743ce5dc2407635ca2e776ba0dfb00a398
-        sourceBlobDigest: sha256:56f1bbe3a050c9505e003bb9790e443084922bff74b072805757076cdb8a136e
+        sourceRevisionDigest: sha256:088d899162941380ec90445852dc7e8c65a8e2eab6b32f552fd7f4fc6f152e76
+        sourceBlobDigest: sha256:feb2a952c0f5757a656e8fed5614e28bc4da195cbeb548b5aaf4fc09aee4ddac
         tags:
             - latest
 targets:
     mistralai-azure-sdk:
         source: mistral-azure-source
         sourceNamespace: mistral-openapi-azure
-        sourceRevisionDigest: sha256:bc53dba5935490a409045de3c39ccf9e90243a289656dd538a542990aa376cca
-        sourceBlobDigest: sha256:4173c3be19775dd2bdd4ce28bb9ae6655650df75f2b689a44c3362d418d69d49
+        sourceRevisionDigest: sha256:becb324b11dfc5155aa0cc420ca312d0af5aecfcbad22fe90066a09561ae4e6a
+        sourceBlobDigest: sha256:84928a6297c3a838dce719ffa3da1e221cba968ce4a6c74d5c3bb41bf86a7e5d
         outLocation: ./packages/mistralai-azure
     mistralai-gcp-sdk:
         source: mistral-google-cloud-source
         sourceNamespace: mistral-openapi-google-cloud
-        sourceRevisionDigest: sha256:ab52d75474e071db240ed9a5367dc6374867b5c9306d478dcfdf8f7b7d08607f
-        sourceBlobDigest: sha256:d5f9c665861d7fedd5093567d13e1f7f6a12b82137fbbecda4708007b15030ba
+        sourceRevisionDigest: sha256:7fee22ae1a434b8919112c7feae87af7f1378952fcc6bde081deb55f65e5bfc2
+        sourceBlobDigest: sha256:a4c011f461c73809a7d6cf1c9823d3c51d5050895aad246287ff14ac971efb8c
         outLocation: ./packages/mistralai-gcp
     mistralai-sdk:
         source: mistral-openapi
         sourceNamespace: mistral-openapi
-        sourceRevisionDigest: sha256:e4d5f5fe40e7f1141006ba40c1d85b743ce5dc2407635ca2e776ba0dfb00a398
-        sourceBlobDigest: sha256:56f1bbe3a050c9505e003bb9790e443084922bff74b072805757076cdb8a136e
+        sourceRevisionDigest: sha256:088d899162941380ec90445852dc7e8c65a8e2eab6b32f552fd7f4fc6f152e76
+        sourceBlobDigest: sha256:feb2a952c0f5757a656e8fed5614e28bc4da195cbeb548b5aaf4fc09aee4ddac
         outLocation: /Users/gaspard/public-mistral/client-ts
 workflow:
     workflowVersion: 1.0.0

--- a/jsr.json
+++ b/jsr.json
@@ -2,7 +2,7 @@
 
 {
   "name": "@mistralai/mistralai",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "exports": {
     ".": "./src/index.ts",    
     "./models/errors": "./src/models/errors/index.ts",    

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mistralai/mistralai",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mistralai/mistralai",
-      "version": "1.1.2",
+      "version": "1.1.3",
       "devDependencies": {
         "@typescript-eslint/eslint-plugin": "^7.7.1",
         "@typescript-eslint/parser": "^7.7.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mistralai/mistralai",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "author": "Speakeasy",
   "main": "./index.js",
   "sideEffects": false,

--- a/packages/mistralai-azure/.speakeasy/gen.lock
+++ b/packages/mistralai-azure/.speakeasy/gen.lock
@@ -1,12 +1,12 @@
 lockVersion: 2.0.0
 id: 01e8a40b-3df3-4d9a-9501-2eb9e0d26c05
 management:
-  docChecksum: 0f6edfd8ad8df6c49b3d429d1af7b9e2
+  docChecksum: 9128fabc3ae45ecc9ed7fae8991b3d3e
   docVersion: 0.0.2
-  speakeasyVersion: 1.372.0
+  speakeasyVersion: 1.373.1
   generationVersion: 2.399.0
-  releaseVersion: 1.1.1
-  configChecksum: 1f81ca42be4e26105da0dd6f61c4eee5
+  releaseVersion: 1.1.2
+  configChecksum: a56cbf1087f24fcd07809bce6cf083c4
   repoURL: https://github.com/mistralai/client-ts.git
   repoSubDirectory: packages/mistralai-azure
   installationURL: https://gitpkg.now.sh/mistralai/client-ts/packages/mistralai-azure

--- a/packages/mistralai-azure/.speakeasy/gen.yaml
+++ b/packages/mistralai-azure/.speakeasy/gen.yaml
@@ -12,7 +12,7 @@ generation:
   auth:
     oAuth2ClientCredentialsEnabled: true
 typescript:
-  version: 1.1.1
+  version: 1.1.2
   additionalDependencies:
     dependencies: {}
     devDependencies: {}

--- a/packages/mistralai-azure/jsr.json
+++ b/packages/mistralai-azure/jsr.json
@@ -2,7 +2,7 @@
 
 {
   "name": "@mistralai/mistralai-azure",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "exports": {
     ".": "./src/index.ts",    
     "./models/errors": "./src/models/errors/index.ts",    

--- a/packages/mistralai-azure/package-lock.json
+++ b/packages/mistralai-azure/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mistralai/mistralai-azure",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mistralai/mistralai-azure",
-      "version": "1.1.1",
+      "version": "1.1.2",
       "devDependencies": {
         "@typescript-eslint/eslint-plugin": "^7.7.1",
         "@typescript-eslint/parser": "^7.7.1",

--- a/packages/mistralai-azure/package.json
+++ b/packages/mistralai-azure/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mistralai/mistralai-azure",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "author": "Speakeasy",
   "main": "./index.js",
   "sideEffects": false,

--- a/packages/mistralai-azure/src/lib/config.ts
+++ b/packages/mistralai-azure/src/lib/config.ts
@@ -55,7 +55,7 @@ export function serverURLFromOptions(options: SDKOptions): URL | null {
 export const SDK_METADATA = {
     language: "typescript",
     openapiDocVersion: "0.0.2",
-    sdkVersion: "1.1.1",
+    sdkVersion: "1.1.2",
     genVersion: "2.399.0",
-    userAgent: "speakeasy-sdk/typescript 1.1.1 2.399.0 0.0.2 @mistralai/mistralai-azure",
+    userAgent: "speakeasy-sdk/typescript 1.1.2 2.399.0 0.0.2 @mistralai/mistralai-azure",
 } as const;

--- a/packages/mistralai-azure/src/models/components/deltamessage.ts
+++ b/packages/mistralai-azure/src/models/components/deltamessage.ts
@@ -13,7 +13,7 @@ import * as z from "zod";
 
 export type DeltaMessage = {
     role?: string | undefined;
-    content?: string | undefined;
+    content?: string | null | undefined;
     toolCalls?: Array<ToolCall> | null | undefined;
 };
 
@@ -21,7 +21,7 @@ export type DeltaMessage = {
 export const DeltaMessage$inboundSchema: z.ZodType<DeltaMessage, z.ZodTypeDef, unknown> = z
     .object({
         role: z.string().optional(),
-        content: z.string().optional(),
+        content: z.nullable(z.string()).optional(),
         tool_calls: z.nullable(z.array(ToolCall$inboundSchema)).optional(),
     })
     .transform((v) => {
@@ -33,7 +33,7 @@ export const DeltaMessage$inboundSchema: z.ZodType<DeltaMessage, z.ZodTypeDef, u
 /** @internal */
 export type DeltaMessage$Outbound = {
     role?: string | undefined;
-    content?: string | undefined;
+    content?: string | null | undefined;
     tool_calls?: Array<ToolCall$Outbound> | null | undefined;
 };
 
@@ -45,7 +45,7 @@ export const DeltaMessage$outboundSchema: z.ZodType<
 > = z
     .object({
         role: z.string().optional(),
-        content: z.string().optional(),
+        content: z.nullable(z.string()).optional(),
         toolCalls: z.nullable(z.array(ToolCall$outboundSchema)).optional(),
     })
     .transform((v) => {

--- a/packages/mistralai-gcp/.speakeasy/gen.lock
+++ b/packages/mistralai-gcp/.speakeasy/gen.lock
@@ -1,12 +1,12 @@
 lockVersion: 2.0.0
 id: c6044247-eaf9-46da-b078-0e1334e93be2
 management:
-  docChecksum: 4cc6e7c5c5ba15491872c600d4a247ef
+  docChecksum: b276b71cb6764f11b10461fe70962781
   docVersion: 0.0.2
-  speakeasyVersion: 1.372.0
+  speakeasyVersion: 1.373.1
   generationVersion: 2.399.0
-  releaseVersion: 1.1.2
-  configChecksum: aee01235f4e46aef1a055407ead7ae83
+  releaseVersion: 1.1.3
+  configChecksum: ac0af1355a07c12fb7c225bd5b49e01c
   repoURL: https://github.com/mistralai/client-ts.git
   repoSubDirectory: packages/mistralai-gcp
   installationURL: https://gitpkg.now.sh/mistralai/client-ts/packages/mistralai-gcp

--- a/packages/mistralai-gcp/.speakeasy/gen.yaml
+++ b/packages/mistralai-gcp/.speakeasy/gen.yaml
@@ -12,7 +12,7 @@ generation:
   auth:
     oAuth2ClientCredentialsEnabled: true
 typescript:
-  version: 1.1.2
+  version: 1.1.3
   additionalDependencies:
     dependencies:
       google-auth-library: ^9.11.0

--- a/packages/mistralai-gcp/jsr.json
+++ b/packages/mistralai-gcp/jsr.json
@@ -2,7 +2,7 @@
 
 {
   "name": "@mistralai/mistralai-gcp",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "exports": {
     ".": "./src/index.ts",    
     "./models/errors": "./src/models/errors/index.ts",    

--- a/packages/mistralai-gcp/package-lock.json
+++ b/packages/mistralai-gcp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mistralai/mistralai-gcp",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mistralai/mistralai-gcp",
-      "version": "1.1.2",
+      "version": "1.1.3",
       "dependencies": {
         "google-auth-library": "^9.11.0"
       },

--- a/packages/mistralai-gcp/package.json
+++ b/packages/mistralai-gcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mistralai/mistralai-gcp",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "author": "Speakeasy",
   "main": "./index.js",
   "sideEffects": false,

--- a/packages/mistralai-gcp/src/lib/config.ts
+++ b/packages/mistralai-gcp/src/lib/config.ts
@@ -55,7 +55,7 @@ export function serverURLFromOptions(options: SDKOptions): URL | null {
 export const SDK_METADATA = {
     language: "typescript",
     openapiDocVersion: "0.0.2",
-    sdkVersion: "1.1.2",
+    sdkVersion: "1.1.3",
     genVersion: "2.399.0",
-    userAgent: "speakeasy-sdk/typescript 1.1.2 2.399.0 0.0.2 @mistralai/mistralai-gcp",
+    userAgent: "speakeasy-sdk/typescript 1.1.3 2.399.0 0.0.2 @mistralai/mistralai-gcp",
 } as const;

--- a/packages/mistralai-gcp/src/models/components/deltamessage.ts
+++ b/packages/mistralai-gcp/src/models/components/deltamessage.ts
@@ -13,7 +13,7 @@ import * as z from "zod";
 
 export type DeltaMessage = {
     role?: string | undefined;
-    content?: string | undefined;
+    content?: string | null | undefined;
     toolCalls?: Array<ToolCall> | null | undefined;
 };
 
@@ -21,7 +21,7 @@ export type DeltaMessage = {
 export const DeltaMessage$inboundSchema: z.ZodType<DeltaMessage, z.ZodTypeDef, unknown> = z
     .object({
         role: z.string().optional(),
-        content: z.string().optional(),
+        content: z.nullable(z.string()).optional(),
         tool_calls: z.nullable(z.array(ToolCall$inboundSchema)).optional(),
     })
     .transform((v) => {
@@ -33,7 +33,7 @@ export const DeltaMessage$inboundSchema: z.ZodType<DeltaMessage, z.ZodTypeDef, u
 /** @internal */
 export type DeltaMessage$Outbound = {
     role?: string | undefined;
-    content?: string | undefined;
+    content?: string | null | undefined;
     tool_calls?: Array<ToolCall$Outbound> | null | undefined;
 };
 
@@ -45,7 +45,7 @@ export const DeltaMessage$outboundSchema: z.ZodType<
 > = z
     .object({
         role: z.string().optional(),
-        content: z.string().optional(),
+        content: z.nullable(z.string()).optional(),
         toolCalls: z.nullable(z.array(ToolCall$outboundSchema)).optional(),
     })
     .transform((v) => {

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -55,7 +55,7 @@ export function serverURLFromOptions(options: SDKOptions): URL | null {
 export const SDK_METADATA = {
     language: "typescript",
     openapiDocVersion: "0.0.2",
-    sdkVersion: "1.1.2",
+    sdkVersion: "1.1.3",
     genVersion: "2.399.0",
-    userAgent: "speakeasy-sdk/typescript 1.1.2 2.399.0 0.0.2 @mistralai/mistralai",
+    userAgent: "speakeasy-sdk/typescript 1.1.3 2.399.0 0.0.2 @mistralai/mistralai",
 } as const;

--- a/src/models/components/deltamessage.ts
+++ b/src/models/components/deltamessage.ts
@@ -13,7 +13,7 @@ import * as z from "zod";
 
 export type DeltaMessage = {
     role?: string | undefined;
-    content?: string | undefined;
+    content?: string | null | undefined;
     toolCalls?: Array<ToolCall> | null | undefined;
 };
 
@@ -21,7 +21,7 @@ export type DeltaMessage = {
 export const DeltaMessage$inboundSchema: z.ZodType<DeltaMessage, z.ZodTypeDef, unknown> = z
     .object({
         role: z.string().optional(),
-        content: z.string().optional(),
+        content: z.nullable(z.string()).optional(),
         tool_calls: z.nullable(z.array(ToolCall$inboundSchema)).optional(),
     })
     .transform((v) => {
@@ -33,7 +33,7 @@ export const DeltaMessage$inboundSchema: z.ZodType<DeltaMessage, z.ZodTypeDef, u
 /** @internal */
 export type DeltaMessage$Outbound = {
     role?: string | undefined;
-    content?: string | undefined;
+    content?: string | null | undefined;
     tool_calls?: Array<ToolCall$Outbound> | null | undefined;
 };
 
@@ -45,7 +45,7 @@ export const DeltaMessage$outboundSchema: z.ZodType<
 > = z
     .object({
         role: z.string().optional(),
-        content: z.string().optional(),
+        content: z.nullable(z.string()).optional(),
         toolCalls: z.nullable(z.array(ToolCall$outboundSchema)).optional(),
     })
     .transform((v) => {


### PR DESCRIPTION
This PR updates the client to accepts "content": null when returning tool call in streaming
Files of interest:
- [azure](https://github.com/mistralai/client-ts/compare/gaspardBT/fix-stream-empty-content?expand=1#diff-7a39b92d05e2068cb7478fb59c764a8e978e94aa536dcee55cf37497f1281219)
- [gcp](https://github.com/mistralai/client-ts/compare/gaspardBT/fix-stream-empty-content?expand=1#diff-13d31310ea185bf4440428a166db120e53cc68a780eaec53d0c6e6d273a48df4)
- [laPlateforme](https://github.com/mistralai/client-ts/compare/gaspardBT/fix-stream-empty-content?expand=1#diff-998ce21e890a374b5a13c833fdc3e9a84293b4c33c2d68b1bb0da887576af9f7)

And an extra example for function calling with streaming [here](https://github.com/mistralai/client-ts/compare/gaspardBT/fix-stream-empty-content?expand=1#diff-b76f3ac8d0d33e1ee1c1fc066a3c797cad9e8c196d9431bc590af36062dbf40a)

fixes https://github.com/mistralai/client-ts/issues/13