### PR TITLE
Fix new GCP model name formatting

### DIFF
--- a/packages/mistralai-gcp/src/sdk/sdk.ts
+++ b/packages/mistralai-gcp/src/sdk/sdk.ts
@@ -25,7 +25,7 @@ const LEGACY_MODEL_ID_FORMAT: { [key: string]: string } = {
 function getModelInfo(model: string): [string, string] {
   let modelId = LEGACY_MODEL_ID_FORMAT[model];
   if (modelId === undefined) {
-    modelId = model;
+    return [model, model];
   }
   model = model.split("-").slice(0, -1).join("-");
   return [model, modelId];
@@ -100,7 +100,7 @@ export class MistralGoogleCloud extends ClientSDK {
         }
 
         const [model, modelId] = getModelInfo(body.model);
-
+        console.log(model, modelId)
         if (!model || !modelId) {
           throw new Error("model must be in the format 'model-version'");
         }

--- a/packages/mistralai-gcp/src/sdk/sdk.ts
+++ b/packages/mistralai-gcp/src/sdk/sdk.ts
@@ -100,7 +100,7 @@ export class MistralGoogleCloud extends ClientSDK {
         }
 
         const [model, modelId] = getModelInfo(body.model);
-        console.log(model, modelId)
+
         if (!model || !modelId) {
           throw new Error("model must be in the format 'model-version'");
         }


### PR DESCRIPTION
fixes https://github.com/mistralai/client-ts/issues/52

The model was not properly passe when using the new format, as it was stripping the version from the body.