### PR TITLE
Revert "chore: disable MCP server generation (#78)"

### DIFF
--- a/.speakeasy/gen.yaml
+++ b/.speakeasy/gen.yaml
@@ -49,4 +49,3 @@ typescript:
   responseFormat: flat
   templateVersion: v2
   useIndexModules: true
-  enableMCPServer: false

--- a/packages/mistralai-azure/.speakeasy/gen.yaml
+++ b/packages/mistralai-azure/.speakeasy/gen.yaml
@@ -45,4 +45,3 @@ typescript:
   responseFormat: flat
   templateVersion: v2
   useIndexModules: true
-  enableMCPServer: false

--- a/packages/mistralai-gcp/.speakeasy/gen.yaml
+++ b/packages/mistralai-gcp/.speakeasy/gen.yaml
@@ -45,4 +45,3 @@ typescript:
   responseFormat: flat
   templateVersion: v2
   useIndexModules: true
-  enableMCPServer: false


### PR DESCRIPTION
This reverts commit 502363c5cde590867d94cd7fe19f71324c5bc4f2.

Reason: We're pinning the Speakeasy version for the incoming release.