### PR TITLE
fix property name includeImageBase64

### DIFF
--- a/examples/src/async_ocr_process_from_file.ts
+++ b/examples/src/async_ocr_process_from_file.ts
@@ -28,6 +28,6 @@ const ocrResponse = await client.ocr.process({
         type: "document_url",
         documentUrl: "https://arxiv.org/pdf/2201.04234"
     },
-    include_image_base64: true
+    includeImageBase64: true
 });
 console.log("OCR ", ocrResponse);

--- a/examples/src/async_ocr_process_from_url.ts
+++ b/examples/src/async_ocr_process_from_url.ts
@@ -9,7 +9,7 @@ const ocrResponse = await client.ocr.process({
         type: "document_url",
         documentUrl: "https://arxiv.org/pdf/2201.04234.pdf"
     },
-    include_image_base64: true
+    includeImageBase64: true
 });
 
 console.log("OCR:", ocrResponse);


### PR DESCRIPTION
Fixed incorrect usage of include_image_base64 → includeImageBase64 in request. By doing this `ts(2561)` can be avoided.