### PR TITLE
fix: add package-lock.json to .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -13,3 +13,4 @@
 /.tshy
 /.tshy-*
 /__tests__
+package-lock.json


### PR DESCRIPTION
This pull request makes a minor update to the `.npmignore` file, ensuring that `package-lock.json` is ignored when publishing the package.

When package.lock.json is published, it causes dependency checkers to improperly flag dependencies listed in the lock file - as an example:


ID | Severity | Source | CVSS | Installed Package (PURL) | Fixed Package | Path | EPSS | Exploit Available | Exploit Last Seen | CWEs
-- | -- | -- | -- | -- | -- | -- | -- | -- | -- | --
CVE-2024-4067 | medium | NVD | 5.3 | pkg:npm/micromatch@4.0.7?dev_dependency=true | 4.0.8 | /app/node_modules/@mistralai/mistralai/packages/mistralai-azure/package-lock.json | 0.00126 |   |   | CWE-1333CWE-1035CWE-937