### PR TITLE
re-export Message type at package root

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -7,3 +7,4 @@ export * as files from "./lib/files.js";
 export { HTTPClient } from "./lib/http.js";
 export type { Fetcher, HTTPClientOptions } from "./lib/http.js";
 export * from "./sdk/sdk.js";
+export type {Messages as Message} from "./models/components/chatcompletionrequest.js"

--- a/src/models/components/chatcompletionrequest.ts
+++ b/src/models/components/chatcompletionrequest.ts
@@ -115,12 +115,7 @@ export type ChatCompletionRequest = {
   /**
    * The prompt(s) to generate completions for, encoded as a list of dict with role and content.
    */
-  messages: Array<
-    | (SystemMessage & { role: "system" })
-    | (ToolMessage & { role: "tool" })
-    | (UserMessage & { role: "user" })
-    | (AssistantMessage & { role: "assistant" })
-  >;
+  messages: Array<Messages>;
   /**
    * Specify the format that the model must output. By default it will use `{ "type": "text" }`. Setting to `{ "type": "json_object" }` enables JSON mode, which guarantees the message the model generates is in JSON. When using JSON mode you MUST also instruct the model to produce JSON yourself with a system or a user message. Setting to `{ "type": "json_schema" }` enables JSON schema mode, which guarantees the message the model generates is in JSON and follows the schema you provide.
    */


### PR DESCRIPTION
During a recent usage of the Mistral client, I noticed that some types I needed, such as `Message`, were defined internally in the SDK but not available at the top level.

In my use case, when consuming the API, I wanted to save the chat result in a variable with proper typing:

```tsx
exporttypeMessage = {
content:string;
role:"user" |"assistant" |"system" |"tool";
};

constchat:Message[] = [];

```

Currently, users would have to import from deep paths or redefine types themselves.

This MR re-exports the `Message` type at the top-level, so it can now be imported directly:

```tsx
importtype {Message }from"@mistralai/mistralai";

constchat:Message[] = [];

```


### **Benefits:**

- Cleaner and simpler imports for SDK users.
- Reduces risk of inconsistencies from manually redefining types.

### **Related issue:**

This MR addresses the discussion in [[GitHub issue #158](https://github.com/mistralai/client-ts/issues/158)](https://github.com/mistralai/client-ts/issues/158).