### PR TITLE
ci: fix publish workflows to trigger on v1 branch

### DIFF
--- a/.github/workflows/sdk_publish_mistralai_azure_sdk.yaml
+++ b/.github/workflows/sdk_publish_mistralai_azure_sdk.yaml
@@ -7,7 +7,7 @@ permissions:
 "on":
   push:
     branches:
-      - main
+      - v1
     paths:
       - packages/mistralai-azure/RELEASES.md
 jobs:

--- a/.github/workflows/sdk_publish_mistralai_gcp_sdk.yaml
+++ b/.github/workflows/sdk_publish_mistralai_gcp_sdk.yaml
@@ -7,7 +7,7 @@ permissions:
 "on":
   push:
     branches:
-      - main
+      - v1
     paths:
       - packages/mistralai-gcp/RELEASES.md
 jobs:

--- a/.github/workflows/sdk_publish_mistralai_sdk.yaml
+++ b/.github/workflows/sdk_publish_mistralai_sdk.yaml
@@ -7,7 +7,7 @@ permissions:
 "on":
   push:
     branches:
-      - main
+      - v1
     paths:
       - RELEASES.md
       - '*/RELEASES.md'


### PR DESCRIPTION
## Summary
- Update all 3 publish workflows (mistralai, gcp, azure) to trigger on `v1` branch instead of `main`
- After the v1/v2 branch split (PR #177), Speakeasy auto-publishing on v1 is broken because the workflows still listen for pushes to `main`

## Changes
- `.github/workflows/sdk_publish_mistralai_sdk.yaml`: `branches: main` → `branches: v1`
- `.github/workflows/sdk_publish_mistralai_gcp_sdk.yaml`: `branches: main` → `branches: v1`
- `.github/workflows/sdk_publish_mistralai_azure_sdk.yaml`: `branches: main` → `branches: v1`