### PR TITLE
docs: fix v2 documentation inconsistencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -481,7 +481,7 @@ Certain SDK methods accept files as part of a multi-part request. It is possible
 > - **Node.js v20+:** Since v20, Node.js comes with a native `openAsBlob` function in [`node:fs`](https://nodejs.org/docs/latest-v20.x/api/fs.html#fsopenasblobpath-options).
 > - **Bun:** The native [`Bun.file`](https://bun.sh/docs/api/file-io#reading-files-bun-file) function produces a file handle that can be used for streaming file uploads.
 > - **Browsers:** All supported browsers return an instance to a [`File`](https://developer.mozilla.org/en-US/docs/Web/API/File) when reading the value from an `<input type="file">` element.
-> - **Node.js v18:** A file stream can be created using the `fileFrom` helper from [`fetch-blob/from.js`](https://www.npmjs.com/package/fetch-blob).
+
 
 ```typescript
 import { Mistral } from "@mistralai/mistralai";

--- a/RUNTIMES.md
+++ b/RUNTIMES.md
@@ -14,7 +14,7 @@ Runtime environments that are explicitly supported are:
 
 - Evergreen browsers which include: Chrome, Safari, Edge, Firefox
 - Node.js active and maintenance LTS releases
-  - Currently, this is v18 and v20
+  - Currently, this is v20 and v22
 - Bun v1 and above
 - Deno v1.39
   - Note that Deno does not currently have native support for streaming file uploads backed by the filesystem ([issue link][deno-file-streaming])

--- a/examples/README.md
+++ b/examples/README.md
@@ -4,7 +4,7 @@ Below is a guide how to run the examples if you have cloned this repo.
 
 ## Prerequisites
 
-- Node.js v18+
+- Node.js v20+
 
 ## How to run the examples locally
 
@@ -40,7 +40,7 @@ npm run test --prefix examples
 If you just want to run one example file, you can do so with:
 
 ```properties
-npm run test --prefix examples -- --files src/stag_async_moderation.ts
+npm run test --prefix examples -- --files src/async_chat_streaming.ts
 ```
 
 ### Realtime transcription from a file

--- a/packages/mistralai-azure/RUNTIMES.md
+++ b/packages/mistralai-azure/RUNTIMES.md
@@ -14,7 +14,7 @@ Runtime environments that are explicitly supported are:
 
 - Evergreen browsers which include: Chrome, Safari, Edge, Firefox
 - Node.js active and maintenance LTS releases
-  - Currently, this is v18 and v20
+  - Currently, this is v20 and v22
 - Bun v1 and above
 - Deno v1.39
   - Note that Deno does not currently have native support for streaming file uploads backed by the filesystem ([issue link][deno-file-streaming])

--- a/packages/mistralai-azure/USAGE.md
+++ b/packages/mistralai-azure/USAGE.md
@@ -7,8 +7,8 @@ This example shows how to create chat completions.
 import { MistralAzure } from "@mistralai/mistralai-azure";
 
 const mistralAzure = new MistralAzure({
-    apiKey: process.env.["AZURE_API_KEY"],
-    endpoint: process.env.["AZURE_ENDPOINT"],
+    apiKey: process.env["AZURE_API_KEY"],
+    endpoint: process.env["AZURE_ENDPOINT"],
 });
 
 async function run() {

--- a/packages/mistralai-azure/docs/sdks/chat/README.md
+++ b/packages/mistralai-azure/docs/sdks/chat/README.md
@@ -20,8 +20,8 @@ Mistral AI provides the ability to stream responses back to a client in order to
 import { MistralAzure } from "@mistralai/mistralai-azure";
 
 const mistralAzure = new MistralAzure({
-    apiKey: process.env.["AZURE_API_KEY"],
-    endpoint: process.env.["AZURE_ENDPOINT"],
+    apiKey: process.env["AZURE_API_KEY"],
+    endpoint: process.env["AZURE_ENDPOINT"],
 });
 
 async function run() {

--- a/packages/mistralai-gcp/RUNTIMES.md
+++ b/packages/mistralai-gcp/RUNTIMES.md
@@ -14,7 +14,7 @@ Runtime environments that are explicitly supported are:
 
 - Evergreen browsers which include: Chrome, Safari, Edge, Firefox
 - Node.js active and maintenance LTS releases
-  - Currently, this is v18 and v20
+  - Currently, this is v20 and v22
 - Bun v1 and above
 - Deno v1.39
   - Note that Deno does not currently have native support for streaming file uploads backed by the filesystem ([issue link][deno-file-streaming])

--- a/packages/mistralai-gcp/docs/sdks/chat/README.md
+++ b/packages/mistralai-gcp/docs/sdks/chat/README.md
@@ -19,13 +19,13 @@ Mistral AI provides the ability to stream responses back to a client in order to
 ```typescript
 import { MistralGCP } from "@mistralai/mistralai-gcp";
 
-const MistralGCP = new MistralGCP({
+const mistralGCP = new MistralGCP({
   region: "europe-west4",
   projectId: process.env["GOOGLE_PROJECT_ID"],
 });
 
 async function run() {
-  const result = await MistralGCP.chat.stream({
+  const result = await mistralGCP.chat.stream({
     model: "mistral-small-latest",
     messages: [
         {
@@ -71,13 +71,13 @@ Chat Completion
 ```typescript
 import { MistralGCP } from "@mistralai/mistralai-gcp";
 
-const MistralGCP = new MistralGCP({
+const mistralGCP = new MistralGCP({
   region: "europe-west4",
   projectId: process.env["GOOGLE_PROJECT_ID"],
 });
 
 async function run() {
-  const result = await MistralGCP.chat.complete({
+  const result = await mistralGCP.chat.complete({
     model: "mistral-small-latest",
     messages: [
         {

--- a/packages/mistralai-gcp/docs/sdks/fim/README.md
+++ b/packages/mistralai-gcp/docs/sdks/fim/README.md
@@ -18,13 +18,13 @@ FIM completion.
 ```typescript
 import { MistralGCP } from "@mistralai/mistralai-gcp";
 
-const MistralGCP = new MistralGCP({
+const mistralGCP = new MistralGCP({
   region: "europe-west4",
   projectId: process.env["GOOGLE_PROJECT_ID"],
 });
 
 async function run() {
-  const result = await MistralGCP.fim.complete({
+  const result = await mistralGCP.fim.complete({
     model: "codestral-2405",
     prompt: "def",
     suffix: "return a+b",


### PR DESCRIPTION
## Summary
- Update Node.js version references from v18/v20 to v20/v22 in all RUNTIMES.md files
- Fix `process.env` syntax errors in Azure USAGE.md and docs (`process.env.["KEY"]` → `process.env["KEY"]`)
- Fix variable shadowing in GCP docs (`const MistralGCP = new MistralGCP` → `const mistralGCP = new MistralGCP`)
- Remove obsolete Node.js v18 `fetch-blob` reference from main README.md
- Fix stale example filename and Node.js prerequisite in examples/README.md

## Test plan
- [ ] Verify all code examples compile/run correctly
- [ ] Review all changed files for accuracy