### PR TITLE
fix: enable auto-publish on main branch for main SDK

### DIFF
--- a/.github/workflows/sdk_publish_mistralai_sdk.yaml
+++ b/.github/workflows/sdk_publish_mistralai_sdk.yaml
@@ -7,7 +7,7 @@ permissions:
 "on":
   push:
     branches:
-      - v1
+      - main
     paths:
       - RELEASES.md
       - '*/RELEASES.md'


### PR DESCRIPTION
## Summary
- Change publish workflow trigger from `v1` to `main` branch
- Merging Speakeasy generation PRs (which update `RELEASES.md`) will now automatically publish to npm
- Manual `workflow_dispatch` trigger still works as fallback