### PR TITLE
fix: explicitly set inferSSEOverload under generation section

### DIFF
--- a/.speakeasy/gen.yaml
+++ b/.speakeasy/gen.yaml
@@ -22,6 +22,7 @@ generation:
     oAuth2ClientCredentialsEnabled: true
     oAuth2PasswordEnabled: false
     hoistGlobalSecurity: true
+  inferSSEOverload: true
   schemas:
     allOfMergeStrategy: shallowMerge
   requestBodyFieldName: ""


### PR DESCRIPTION
## Summary
- Explicitly sets `inferSSEOverload: true` under the `generation:` section in gen.yaml
- Ensures Speakeasy generates proper type-safe overloads for endpoints returning both JSON and SSE (e.g. speech)

## Test plan
- [x] Verify next SDK regeneration still produces correct streaming types