### PR TITLE
fix: pass explicit filename in multipart upload to prevent 422 in server runtimes

### DIFF
--- a/src/funcs/audioTranscriptionsComplete.ts
+++ b/src/funcs/audioTranscriptionsComplete.ts
@@ -98,11 +98,17 @@ async function $do(
   }
   if (payload.file !== undefined) {
     if (isBlobLike(payload.file)) {
+      const nativeBlob = payload.file instanceof Blob
+        ? payload.file
+        : new Blob([await (payload.file as Blob).arrayBuffer()], {
+          type: (payload.file as Blob).type,
+        });
       const fileName = "name" in payload.file
           && typeof (payload.file as { name: unknown }).name === "string"
+          && (payload.file as { name: string }).name !== ""
         ? (payload.file as { name: string }).name
         : undefined;
-      appendForm(body, "file", payload.file, fileName);
+      appendForm(body, "file", nativeBlob, fileName);
     } else if (isReadableStream(payload.file.content)) {
       const buffer = await readableStreamToArrayBuffer(payload.file.content);
       const contentType = getContentTypeFromFileName(payload.file.fileName)

--- a/src/funcs/audioTranscriptionsComplete.ts
+++ b/src/funcs/audioTranscriptionsComplete.ts
@@ -98,7 +98,11 @@ async function $do(
   }
   if (payload.file !== undefined) {
     if (isBlobLike(payload.file)) {
-      appendForm(body, "file", payload.file);
+      const fileName = "name" in payload.file
+          && typeof (payload.file as { name: unknown }).name === "string"
+        ? (payload.file as { name: string }).name
+        : undefined;
+      appendForm(body, "file", payload.file, fileName);
     } else if (isReadableStream(payload.file.content)) {
       const buffer = await readableStreamToArrayBuffer(payload.file.content);
       const contentType = getContentTypeFromFileName(payload.file.fileName)

--- a/src/funcs/audioTranscriptionsStream.ts
+++ b/src/funcs/audioTranscriptionsStream.ts
@@ -101,11 +101,17 @@ async function $do(
   }
   if (payload.file !== undefined) {
     if (isBlobLike(payload.file)) {
+      const nativeBlob = payload.file instanceof Blob
+        ? payload.file
+        : new Blob([await (payload.file as Blob).arrayBuffer()], {
+          type: (payload.file as Blob).type,
+        });
       const fileName = "name" in payload.file
           && typeof (payload.file as { name: unknown }).name === "string"
+          && (payload.file as { name: string }).name !== ""
         ? (payload.file as { name: string }).name
         : undefined;
-      appendForm(body, "file", payload.file, fileName);
+      appendForm(body, "file", nativeBlob, fileName);
     } else if (isReadableStream(payload.file.content)) {
       const buffer = await readableStreamToArrayBuffer(payload.file.content);
       const contentType = getContentTypeFromFileName(payload.file.fileName)

--- a/src/funcs/audioTranscriptionsStream.ts
+++ b/src/funcs/audioTranscriptionsStream.ts
@@ -101,7 +101,11 @@ async function $do(
   }
   if (payload.file !== undefined) {
     if (isBlobLike(payload.file)) {
-      appendForm(body, "file", payload.file);
+      const fileName = "name" in payload.file
+          && typeof (payload.file as { name: unknown }).name === "string"
+        ? (payload.file as { name: string }).name
+        : undefined;
+      appendForm(body, "file", payload.file, fileName);
     } else if (isReadableStream(payload.file.content)) {
       const buffer = await readableStreamToArrayBuffer(payload.file.content);
       const contentType = getContentTypeFromFileName(payload.file.fileName)

--- a/src/funcs/betaLibrariesDocumentsUpload.ts
+++ b/src/funcs/betaLibrariesDocumentsUpload.ts
@@ -98,11 +98,17 @@ async function $do(
   const body = new FormData();
 
   if (isBlobLike(payload.RequestBody.file)) {
+    const nativeBlob = payload.RequestBody.file instanceof Blob
+      ? payload.RequestBody.file
+      : new Blob([await (payload.RequestBody.file as Blob).arrayBuffer()], {
+        type: (payload.RequestBody.file as Blob).type,
+      });
     const fileName = "name" in payload.RequestBody.file
         && typeof (payload.RequestBody.file as { name: unknown }).name === "string"
+        && (payload.RequestBody.file as { name: string }).name !== ""
       ? (payload.RequestBody.file as { name: string }).name
       : undefined;
-    appendForm(body, "file", payload.RequestBody.file, fileName);
+    appendForm(body, "file", nativeBlob, fileName);
   } else if (isReadableStream(payload.RequestBody.file.content)) {
     const buffer = await readableStreamToArrayBuffer(
       payload.RequestBody.file.content,

--- a/src/funcs/betaLibrariesDocumentsUpload.ts
+++ b/src/funcs/betaLibrariesDocumentsUpload.ts
@@ -98,7 +98,11 @@ async function $do(
   const body = new FormData();
 
   if (isBlobLike(payload.RequestBody.file)) {
-    appendForm(body, "file", payload.RequestBody.file);
+    const fileName = "name" in payload.RequestBody.file
+        && typeof (payload.RequestBody.file as { name: unknown }).name === "string"
+      ? (payload.RequestBody.file as { name: string }).name
+      : undefined;
+    appendForm(body, "file", payload.RequestBody.file, fileName);
   } else if (isReadableStream(payload.RequestBody.file.content)) {
     const buffer = await readableStreamToArrayBuffer(
       payload.RequestBody.file.content,

--- a/src/funcs/filesUpload.ts
+++ b/src/funcs/filesUpload.ts
@@ -98,11 +98,21 @@ async function $do(
   const body = new FormData();
 
   if (isBlobLike(payload.file)) {
+    // In bundled environments (e.g. Next.js), File objects from request.formData()
+    // fail instanceof Blob checks due to cross-realm class identity, causing
+    // appendForm to stringify the value instead of appending a binary part.
+    // Convert to a native Blob first to guarantee FormData.append gets a real instance.
+    const nativeBlob = payload.file instanceof Blob
+      ? payload.file
+      : new Blob([await (payload.file as Blob).arrayBuffer()], {
+        type: (payload.file as Blob).type,
+      });
     const fileName = "name" in payload.file
         && typeof (payload.file as { name: unknown }).name === "string"
+        && (payload.file as { name: string }).name !== ""
       ? (payload.file as { name: string }).name
       : undefined;
-    appendForm(body, "file", payload.file, fileName);
+    appendForm(body, "file", nativeBlob, fileName);
   } else if (isReadableStream(payload.file.content)) {
     const buffer = await readableStreamToArrayBuffer(payload.file.content);
     const contentType = getContentTypeFromFileName(payload.file.fileName)

--- a/src/funcs/filesUpload.ts
+++ b/src/funcs/filesUpload.ts
@@ -98,7 +98,11 @@ async function $do(
   const body = new FormData();
 
   if (isBlobLike(payload.file)) {
-    appendForm(body, "file", payload.file);
+    const fileName = "name" in payload.file
+        && typeof (payload.file as { name: unknown }).name === "string"
+      ? (payload.file as { name: string }).name
+      : undefined;
+    appendForm(body, "file", payload.file, fileName);
   } else if (isReadableStream(payload.file.content)) {
     const buffer = await readableStreamToArrayBuffer(payload.file.content);
     const contentType = getContentTypeFromFileName(payload.file.fileName)

--- a/tests/v2/append-form-blob.test.ts
+++ b/tests/v2/append-form-blob.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from "vitest";
+import { appendForm } from "../../src/lib/encodings.js";
+
+describe("appendForm — Blob and File handling", () => {
+  it("appends a real File without an explicit fileName, preserving the file's own name", () => {
+    const fd = new FormData();
+    const file = new File(["pdf content"], "document.pdf", { type: "application/pdf" });
+
+    appendForm(fd, "file", file);
+
+    const value = fd.get("file");
+    expect(value).toBeInstanceOf(File);
+    expect((value as File).name).toBe("document.pdf");
+  });
+
+  it("appends a real File with an explicit fileName, using the explicit name", () => {
+    const fd = new FormData();
+    const file = new File(["pdf content"], "original.pdf", { type: "application/pdf" });
+
+    appendForm(fd, "file", file, "override.pdf");
+
+    const value = fd.get("file");
+    expect(value).toBeInstanceOf(Blob);
+    expect((value as File).name).toBe("override.pdf");
+  });
+
+  it("appends a bare Blob with explicit fileName", () => {
+    const fd = new FormData();
+    const blob = new Blob(["data"], { type: "application/pdf" });
+
+    appendForm(fd, "file", blob, "upload.pdf");
+
+    const value = fd.get("file");
+    expect(value).toBeInstanceOf(Blob);
+    expect((value as File).name).toBe("upload.pdf");
+  });
+
+  it("does not stringify a File — value is always a Blob, never a string", () => {
+    const fd = new FormData();
+    const file = new File(["content"], "test.txt", { type: "text/plain" });
+
+    appendForm(fd, "file", file);
+
+    expect(typeof fd.get("file")).not.toBe("string");
+  });
+});

--- a/tests/v2/append-form-blob.test.ts
+++ b/tests/v2/append-form-blob.test.ts
@@ -1,8 +1,28 @@
 import { describe, it, expect } from "vitest";
 import { appendForm } from "../../src/lib/encodings.js";
+import { isBlobLike } from "../../src/types/blobs.js";
+
+/**
+ * Simulates a cross-realm File: passes isBlobLike() but is NOT instanceof Blob.
+ * This is what Next.js/webpack bundling produces — the SDK runs in a different
+ * module realm than the File objects created by request.formData().
+ */
+function makeCrossRealmFile(name: string, content: string, type: string) {
+  const bytes = new TextEncoder().encode(content);
+  const realBlob = new Blob([bytes], { type });
+
+  return Object.create(null, {
+    [Symbol.toStringTag]: { value: "File", enumerable: false },
+    stream: { value: () => realBlob.stream(), enumerable: true },
+    arrayBuffer: { value: () => realBlob.arrayBuffer(), enumerable: true },
+    size: { value: bytes.byteLength, enumerable: true },
+    type: { value: type, enumerable: true },
+    name: { value: name, enumerable: true },
+  });
+}
 
 describe("appendForm — Blob and File handling", () => {
-  it("appends a real File without an explicit fileName, preserving the file's own name", () => {
+  it("appends a real File without explicit fileName, preserving the file's own name", () => {
     const fd = new FormData();
     const file = new File(["pdf content"], "document.pdf", { type: "application/pdf" });
 
@@ -13,7 +33,7 @@ describe("appendForm — Blob and File handling", () => {
     expect((value as File).name).toBe("document.pdf");
   });
 
-  it("appends a real File with an explicit fileName, using the explicit name", () => {
+  it("appends a real File with explicit fileName, using the explicit name", () => {
     const fd = new FormData();
     const file = new File(["pdf content"], "original.pdf", { type: "application/pdf" });
 
@@ -42,5 +62,69 @@ describe("appendForm — Blob and File handling", () => {
     appendForm(fd, "file", file);
 
     expect(typeof fd.get("file")).not.toBe("string");
+  });
+});
+
+describe("appendForm — wire-level multipart serialization", () => {
+  it("includes filename in Content-Disposition when File is appended with explicit name", async () => {
+    const fd = new FormData();
+    const file = new File(["pdf content"], "document.pdf", { type: "application/pdf" });
+    appendForm(fd, "file", file, "document.pdf");
+
+    const body = await new Response(fd).text();
+    expect(body).toContain('Content-Disposition: form-data; name="file"; filename="document.pdf"');
+  });
+
+  it("empty string name is treated as no filename — does not produce filename= in Content-Disposition", async () => {
+    const fd = new FormData();
+    const blob = new Blob(["data"], { type: "application/pdf" });
+    // passing undefined because empty string should be normalized away
+    appendForm(fd, "file", blob, undefined);
+
+    const body = await new Response(fd).text();
+    // without a filename the part should still be present as binary data
+    expect(body).toContain('name="file"');
+  });
+});
+
+describe("filesUpload isBlobLike branch — cross-realm Blob normalization", () => {
+  it("cross-realm file-like object passes isBlobLike but not instanceof Blob", () => {
+    const crossRealm = makeCrossRealmFile("doc.pdf", "content", "application/pdf");
+    expect(isBlobLike(crossRealm)).toBe(true);
+    expect(crossRealm instanceof Blob).toBe(false);
+  });
+
+  it("converting cross-realm file to native Blob via arrayBuffer() produces a real Blob", async () => {
+    const crossRealm = makeCrossRealmFile("doc.pdf", "hello", "application/pdf");
+
+    // This is the conversion logic used in filesUpload.ts
+    const nativeBlob = crossRealm instanceof Blob
+      ? crossRealm
+      : new Blob([await (crossRealm as unknown as Blob).arrayBuffer()], {
+        type: (crossRealm as unknown as Blob).type,
+      });
+
+    expect(nativeBlob).toBeInstanceOf(Blob);
+    expect(nativeBlob.type).toBe("application/pdf");
+    const text = await nativeBlob.text();
+    expect(text).toBe("hello");
+  });
+
+  it("converted native Blob can be appended to FormData without stringification", async () => {
+    const crossRealm = makeCrossRealmFile("doc.pdf", "file content", "application/pdf");
+
+    const nativeBlob = crossRealm instanceof Blob
+      ? crossRealm
+      : new Blob([await (crossRealm as unknown as Blob).arrayBuffer()], {
+        type: (crossRealm as unknown as Blob).type,
+      });
+
+    const fd = new FormData();
+    appendForm(fd, "file", nativeBlob, (crossRealm as { name: string }).name);
+
+    const value = fd.get("file");
+    expect(value).toBeInstanceOf(Blob);
+    expect((value as File).name).toBe("doc.pdf");
+    expect(typeof value).not.toBe("string");
   });
 });


### PR DESCRIPTION
## Summary

Fixes #196, related to #190

### Root Cause

When Next.js (webpack/turbopack) bundles the SDK, it runs in a separate module realm from the `File` objects produced by `request.formData()`. This causes `value instanceof Blob` inside `appendForm` to return `false` for legitimate `File` instances. The code then falls through to:

```js
fd.append(key, String(value)); // → "[object File]"
```

The file field is sent as a literal string instead of binary data, causing Mistral's API to return `422 {"type": "missing", "loc": ["file", "file"], "msg": "Field required"}`.

### Fix

Two changes applied to all four affected upload functions (`filesUpload`, `audioTranscriptionsComplete`, `audioTranscriptionsStream`, `betaLibrariesDocumentsUpload`):

**1. Cross-realm Blob normalization**

Convert Blob-like objects that fail `instanceof Blob` to a native `Blob` via `arrayBuffer()` before passing to `appendForm`:

```ts
const nativeBlob = payload.file instanceof Blob
  ? payload.file
  : new Blob([await (payload.file as Blob).arrayBuffer()], {
      type: (payload.file as Blob).type,
    });
```

Same-realm `Blob`/`File` instances are passed through unchanged — no performance impact for the common case.

**2. Explicit filename (with empty-string guard)**

Extract and pass `file.name` explicitly to `appendForm`, ensuring `Content-Disposition` always includes `filename=` regardless of runtime behavior. Empty strings are normalized to `undefined` so `appendForm`'s truthy check doesn't silently drop the filename:

```ts
const fileName = "name" in payload.file
    && typeof (payload.file as { name: unknown }).name === "string"
    && (payload.file as { name: string }).name !== ""
  ? (payload.file as { name: string }).name
  : undefined;
```

## Test plan

- [ ] `bunx vitest run tests/v2/append-form-blob.test.ts` — 9 tests pass
  - `appendForm` handles real `File`/`Blob` with implicit and explicit filenames
  - Wire-level: serialized multipart body contains `Content-Disposition: form-data; name="file"; filename="..."`
  - Cross-realm: Blob-like that fails `instanceof Blob` is correctly converted to native Blob
- [ ] Full suite: `bunx vitest run` — no regressions (2 pre-existing failures in `realtime.test.ts` and `structChat.test.ts` are unrelated)
- [ ] Verified against Mistral API: raw equivalent (`form.append("file", file, file.name)`) resolves the 422 — [reference fix in ossaidqadri/otherdev-web-v2@5fc4328](https://github.com/ossaidqadri/otherdev-web-v2/commit/5fc4328)