### PR TITLE
feat: expose OCR support in Azure TypeScript SDK

### DIFF
--- a/packages/mistralai-azure/src/sdk/sdk.ts
+++ b/packages/mistralai-azure/src/sdk/sdk.ts
@@ -1,6 +1,7 @@
 import { SDKOptions } from "../lib/config.js";
 import { ClientSDK } from "../lib/sdks.js";
 import { Chat } from "./chat.js";
+import { Ocr } from "./ocr.js";
 
 export type AzureOptions = {
     /** Your AzureAI Endpoint for more information see https://docs.mistral.ai/deployment/cloud/azure/ */
@@ -24,5 +25,10 @@ export class MistralAzure extends ClientSDK {
     private _chat?: Chat;
     get chat(): Chat {
         return (this._chat ??= new Chat(this._options));
+    }
+
+    private _ocr?: Ocr;
+    get ocr(): Ocr {
+        return (this._ocr ??= new Ocr(this._options));
     }
 }


### PR DESCRIPTION
## Summary
- The `Ocr` class and all OCR types were already generated by Speakeasy but never wired up in `MistralAzure`
- Adds the `ocr` getter to `MistralAzure` so users can call `client.ocr.process()`
- Verified it constructs the correct URL (`{endpoint}/v1/ocr`) and parses responses

## Ref
- #122
- #157

## Test plan
- [x] `npx tsc --noEmit` passes (no type errors)
- [x] Verified `client.ocr.process()` is accessible and builds correct request URL
- [x] Verified OCR response is parsed with correct camelCase field mapping