### PR TITLE
fix: handle malformed JSON in structChat parsed response

### DIFF
--- a/src/extra/structChat.ts
+++ b/src/extra/structChat.ts
@@ -118,23 +118,43 @@ export function convertToParsedChatCompletionResponse<T extends z.ZodTypeAny>(re
   for (const _choice of response.choices) {
     if (_choice.message === null || typeof _choice.message === 'undefined') {
       parsedChoices.push({..._choice, message: undefined});
-    } else {
-      if (_choice.message.content !== null && typeof _choice.message.content !== 'undefined' && !Array.isArray(_choice.message.content)) {
+    } else if (
+      _choice.message.content !== null
+      && typeof _choice.message.content !== 'undefined'
+      && !Array.isArray(_choice.message.content)
+    ) {
+      let parsed: z.infer<T> | undefined;
+      try {
+        parsed = responseFormat.safeParse(JSON.parse(_choice.message.content)).data;
+      } catch {
+        // JSON.parse can throw if the model returns malformed JSON
+        // (e.g. truncated output when finish_reason is "length").
+        // Leave parsed as undefined so callers can detect the failure.
+        parsed = undefined;
+      }
       parsedChoices.push({
         ..._choice,
         message: {
           ..._choice.message,
-          parsed: responseFormat.safeParse(JSON.parse(_choice.message.content)).data,
-        }
+          parsed,
+        },
       });
-      }
+    } else {
+      // content is null, undefined, or an array of content chunks;
+      // preserve the choice without a parsed field.
+      parsedChoices.push({
+        ..._choice,
+        message: {
+          ..._choice.message,
+          parsed: undefined,
+        },
+      });
     }
   }
   return {
     ...response,
     choices: parsedChoices,
   };
-
 }
 
   // Function to convert Zod schema to strict JSON schema

--- a/tests/extra/structChat.test.ts
+++ b/tests/extra/structChat.test.ts
@@ -188,6 +188,137 @@ describe("convertToParsedChatCompletionResponse", () => {
       convertToParsedChatCompletionResponse(raw_response, MathDemonstration)
     ).toStrictEqual(ccr_response);
   });
+
+  it("should set parsed to undefined when content is malformed JSON", () => {
+    const truncatedResponse: components.ChatCompletionResponse = {
+      id: "test-malformed",
+      object: "chat.completion",
+      model: "mistral-tiny-latest",
+      usage: { promptTokens: 10, completionTokens: 5, totalTokens: 15 },
+      created: 1700000000,
+      choices: [
+        {
+          index: 0,
+          message: {
+            content: '{"steps": [{"explanation": "truncated',
+            toolCalls: null,
+            prefix: false,
+            role: "assistant",
+          },
+          finishReason: "length",
+        },
+      ],
+    };
+
+    const result = convertToParsedChatCompletionResponse(
+      truncatedResponse,
+      MathDemonstration,
+    );
+
+    expect(result.choices).toHaveLength(1);
+    expect(result.choices![0].message).toBeDefined();
+    expect(result.choices![0].message!.parsed).toBeUndefined();
+    expect(result.choices![0].message!.content).toBe(
+      '{"steps": [{"explanation": "truncated',
+    );
+  });
+
+  it("should set parsed to undefined when content is valid JSON but fails schema validation", () => {
+    const wrongShapeResponse: components.ChatCompletionResponse = {
+      id: "test-wrong-shape",
+      object: "chat.completion",
+      model: "mistral-tiny-latest",
+      usage: { promptTokens: 10, completionTokens: 5, totalTokens: 15 },
+      created: 1700000000,
+      choices: [
+        {
+          index: 0,
+          message: {
+            content: '{"wrong_field": "not matching schema"}',
+            toolCalls: null,
+            prefix: false,
+            role: "assistant",
+          },
+          finishReason: "stop",
+        },
+      ],
+    };
+
+    const result = convertToParsedChatCompletionResponse(
+      wrongShapeResponse,
+      MathDemonstration,
+    );
+
+    expect(result.choices).toHaveLength(1);
+    expect(result.choices![0].message).toBeDefined();
+    expect(result.choices![0].message!.parsed).toBeUndefined();
+  });
+
+  it("should preserve choices when content is null", () => {
+    const nullContentResponse: components.ChatCompletionResponse = {
+      id: "test-null-content",
+      object: "chat.completion",
+      model: "mistral-tiny-latest",
+      usage: { promptTokens: 10, completionTokens: 5, totalTokens: 15 },
+      created: 1700000000,
+      choices: [
+        {
+          index: 0,
+          message: {
+            content: null,
+            toolCalls: null,
+            prefix: false,
+            role: "assistant",
+          },
+          finishReason: "stop",
+        },
+      ],
+    };
+
+    const result = convertToParsedChatCompletionResponse(
+      nullContentResponse,
+      MathDemonstration,
+    );
+
+    expect(result.choices).toHaveLength(1);
+    expect(result.choices![0].message).toBeDefined();
+    expect(result.choices![0].message!.parsed).toBeUndefined();
+  });
+
+  it("should return empty choices array for empty choices", () => {
+    const emptyChoicesResponse: components.ChatCompletionResponse = {
+      id: "test-empty",
+      object: "chat.completion",
+      model: "mistral-tiny-latest",
+      usage: { promptTokens: 10, completionTokens: 0, totalTokens: 10 },
+      created: 1700000000,
+      choices: [],
+    };
+
+    const result = convertToParsedChatCompletionResponse(
+      emptyChoicesResponse,
+      MathDemonstration,
+    );
+
+    expect(result.choices).toEqual([]);
+  });
+
+  it("should return undefined choices when choices is undefined", () => {
+    const noChoicesResponse: components.ChatCompletionResponse = {
+      id: "test-undefined",
+      object: "chat.completion",
+      model: "mistral-tiny-latest",
+      usage: { promptTokens: 10, completionTokens: 0, totalTokens: 10 },
+      created: 1700000000,
+    };
+
+    const result = convertToParsedChatCompletionResponse(
+      noChoicesResponse,
+      MathDemonstration,
+    );
+
+    expect(result.choices).toBeUndefined();
+  });
 });
 
 describe("responseFormatFromZodObject", () => {


### PR DESCRIPTION
## Summary

`convertToParsedChatCompletionResponse` in `src/extra/structChat.ts` crashes with an unhandled `SyntaxError` when the model returns malformed JSON content (common when `finish_reason` is `"length"` due to token limit truncation).

**Bug**: The `JSON.parse()` call on [line 127](https://github.com/mistralai/client-ts/blob/main/src/extra/structChat.ts#L127) is unguarded. While `responseFormat.safeParse()` correctly uses Zod's safe parsing, the preceding `JSON.parse()` throws on invalid JSON, propagating an uncaught exception to the caller.

**Secondary issue**: When a choice has `null`, `undefined`, or array content, the choice was silently dropped from the output (the inner `if` had no `else` branch), causing the response to have fewer choices than expected.

## Changes

- Wrap `JSON.parse()` in a try/catch so malformed JSON gracefully sets `parsed` to `undefined` instead of throwing
- Add an `else` branch to preserve choices with non-string content (null/undefined/array) with `parsed: undefined`
- Add 5 new test cases covering: malformed JSON, schema validation failure, null content, empty choices, undefined choices

## Test plan

- [x] All 8 `structChat` tests pass (3 existing + 5 new)
- [x] Full test suite passes (39/39 tests)
- [ ] Verify behavior with a real truncated response from the API