### PR TITLE
fix: harden deprecation warning hook against non-JSON responses

### DIFF
--- a/src/hooks/deprecation_warning.ts
+++ b/src/hooks/deprecation_warning.ts
@@ -11,8 +11,7 @@ export class DeprecationWarningHook implements AfterSuccessHook {
                 console.warn(
                     `WARNING: The model ${model} is deprecated and will be removed on ${response.headers.get(HEADER_MODEL_DEPRECATION_TIMESTAMP)}. Please refer to https://docs.mistral.ai/getting-started/models/#api-versioning for more information.`
                 );
-            });
-
+            }).catch(() => {});
         }
         return response;
     }


### PR DESCRIPTION
## Summary

While auditing custom code in the TypeScript SDK, discovered that `src/hooks/deprecation_warning.ts` calls `response.clone().json().then(...)` when the `x-model-deprecation-timestamp` header is present, but there's no `.catch()`. If an endpoint ever returns non-JSON with that header, we get an unhandled promise rejection.

Added a `.catch()` that silently swallows the error. The deprecation warning is nice-to-have, not critical, so failing silently is fine.

## Test plan

* All existing tests pass (34/34)
* Lint passes