### PR TITLE
chore: bump Speakeasy CLI from v1.761.1 to v1.761.9

### DIFF
--- a/.speakeasy/workflow.yaml
+++ b/.speakeasy/workflow.yaml
@@ -1,5 +1,5 @@
 workflowVersion: 1.0.0
-speakeasyVersion: v1.761.1
+speakeasyVersion: v1.761.9
 sources:
     mistral-azure-source:
         inputs:


### PR DESCRIPTION
## Summary

Bump Speakeasy CLI from v1.761.1 to v1.761.9

### Notable changes

**TypeScript fixes:**
* v1.761.2: normalize cross-realm Blob-like objects in appendForm upload handling
* v1.761.4: oxlint pattern fix
* v1.761.7: default response handling in AfterErrorHook
* v1.761.8: debug logger no longer buffers JSONL/NDJSON streaming responses

**Other:**
* v1.761.6: support mcpRegistry in workflow.yaml
* v1.761.9: resolve expired PGP key, mitigate CVE-2026-24765 (PHP/Terraform)

## Test plan

* Trigger "Generate MISTRALAI-SDK" workflow after merge to verify SDK regeneration works