### PR TITLE
docs(examples): add chat reasoningEffort examples

### DIFF
--- a/examples/src/reasoning.ts
+++ b/examples/src/reasoning.ts
@@ -1,0 +1,50 @@
+import { Mistral } from "@mistralai/mistralai";
+
+const apiKey = process.env["MISTRAL_API_KEY"];
+if (!apiKey) {
+  throw new Error("missing MISTRAL_API_KEY environment variable");
+}
+
+const client = new Mistral({ apiKey });
+
+const chatResponse = await client.chat.complete(
+  {
+    model: "mistral-medium-3-5",
+    messages: [
+      {
+        role: "user",
+        content:
+          "John is one of 4 children. The first sister is 4 years old. " +
+          "Next year, the second sister will be twice as old as the first sister. " +
+          "The third sister is two years older than the second sister. " +
+          "The third sister is half the age of her older brother. " +
+          "How old is John?",
+      },
+    ],
+    reasoningEffort: "high",
+    temperature: 0.7,
+  },
+  // Bump request timeout because reasoning runs can be long.
+  { timeoutMs: 300_000 },
+);
+
+// With reasoningEffort="high", message.content is an array of chunks.
+// With reasoningEffort="none", message.content is a plain string.
+const content = chatResponse.choices[0]?.message.content;
+if (typeof content === "string") {
+  console.log(content);
+} else {
+  for (const chunk of content ?? []) {
+    if (chunk.type === "thinking") {
+      console.log("--- thinking ---");
+      for (const inner of chunk.thinking) {
+        if (inner.type === "text") {
+          console.log(inner.text);
+        }
+      }
+      console.log("--- /thinking ---");
+    } else if (chunk.type === "text") {
+      console.log(chunk.text);
+    }
+  }
+}

--- a/examples/src/reasoning_multi_turn.ts
+++ b/examples/src/reasoning_multi_turn.ts
@@ -1,0 +1,77 @@
+// Multi-turn conversation with a reasoning model.
+//
+// IMPORTANT: for Mistral Medium 3.5, always replay the assistant turn
+// back into `messages` with its ThinkChunks intact. Dropping the
+// reasoning trace across turns DEGRADES the model's performance.
+//
+// This example runs a 3-turn math chain and prints per-turn token
+// usage. The prompt grows as the reasoning trace accumulates; that
+// growth is expected.
+
+import { Mistral } from "@mistralai/mistralai";
+import type { ChatCompletionRequestMessage } from "@mistralai/mistralai/models/components";
+
+const apiKey = process.env["MISTRAL_API_KEY"];
+if (!apiKey) {
+  throw new Error("missing MISTRAL_API_KEY environment variable");
+}
+
+const MODEL = "mistral-medium-3-5";
+const TURNS = [
+  "What is 17 * 23?",
+  "Now multiply that by 3.",
+  "And subtract 100 from the result.",
+];
+
+function finalText(content: unknown): string {
+  if (typeof content === "string") return content;
+  if (!Array.isArray(content)) return "";
+  return content
+    .filter((c): c is { type: "text"; text: string } => c?.type === "text")
+    .map((c) => c.text)
+    .join("");
+}
+
+const client = new Mistral({ apiKey });
+
+const messages: ChatCompletionRequestMessage[] = [];
+let totalPrompt = 0;
+let totalCompletion = 0;
+
+for (let i = 0; i < TURNS.length; i++) {
+  messages.push({ role: "user", content: TURNS[i]! });
+
+  const response = await client.chat.complete(
+    {
+      model: MODEL,
+      messages,
+      reasoningEffort: "high",
+      temperature: 0.7,
+    },
+    // Bump request timeout because reasoning runs can be long.
+    { timeoutMs: 300_000 },
+  );
+
+  const message = response.choices[0]!.message!;
+  const promptTokens = response.usage.promptTokens ?? 0;
+  const completionTokens = response.usage.completionTokens ?? 0;
+  totalPrompt += promptTokens;
+  totalCompletion += completionTokens;
+
+  console.log(
+    `turn ${i + 1}: prompt=${String(promptTokens).padStart(4)} ` +
+      `completion=${String(completionTokens).padStart(4)}  -> ${finalText(message.content)}`,
+  );
+
+  // Append the full assistant message back into history so the
+  // ThinkChunks are preserved across turns.
+  messages.push({
+    role: "assistant",
+    content: message.content,
+  });
+}
+
+console.log(
+  `TOTAL: prompt=${totalPrompt} completion=${totalCompletion} ` +
+    `(sum ${totalPrompt + totalCompletion})`,
+);

--- a/examples/src/reasoning_response_shape.ts
+++ b/examples/src/reasoning_response_shape.ts
@@ -1,0 +1,33 @@
+// Print the raw shape of a chat response when using `reasoningEffort`.
+// Run this first to see what ThinkChunk / TextChunk look like in the wire
+// format, then move on to the other reasoning_*.ts examples.
+
+import { Mistral } from "@mistralai/mistralai";
+
+const apiKey = process.env["MISTRAL_API_KEY"];
+if (!apiKey) {
+  throw new Error("missing MISTRAL_API_KEY environment variable");
+}
+
+const client = new Mistral({ apiKey });
+
+const prompt = "What is 12 * 14? Answer in one short sentence.";
+
+for (const effort of ["high", "none"] as const) {
+  console.log(`\n========== reasoningEffort=${JSON.stringify(effort)} ==========`);
+  const response = await client.chat.complete(
+    {
+      model: "mistral-medium-3-5",
+      messages: [{ role: "user", content: prompt }],
+      reasoningEffort: effort,
+      temperature: 0.7,
+    },
+    // Bump request timeout because reasoning runs can be long.
+    { timeoutMs: 300_000 },
+  );
+
+  const content = response.choices[0]?.message?.content;
+  console.log(`typeof content = ${Array.isArray(content) ? "Array" : typeof content}`);
+  console.log("content =");
+  console.log(JSON.stringify(content, null, 2));
+}

--- a/examples/src/reasoning_with_streaming.ts
+++ b/examples/src/reasoning_with_streaming.ts
@@ -1,0 +1,68 @@
+import { Mistral } from "@mistralai/mistralai";
+
+const apiKey = process.env["MISTRAL_API_KEY"];
+if (!apiKey) {
+  throw new Error("missing MISTRAL_API_KEY environment variable");
+}
+
+const client = new Mistral({ apiKey });
+
+// While the model is thinking, delta.content is an array containing a
+// ThinkChunk. After the thinking phase ends, delta.content arrives as
+// plain string fragments. The transition event may contain both a closing
+// ThinkChunk and the first TextChunk in a single array.
+const stream = await client.chat.stream(
+  {
+    model: "mistral-medium-3-5",
+    messages: [
+      {
+        role: "user",
+        content:
+          "If a train leaves Paris at 9am going 120 km/h and another " +
+          "leaves Lyon at 10am going 150 km/h on the same track, " +
+          "when do they meet? Paris-Lyon is 465 km.",
+      },
+    ],
+    reasoningEffort: "high",
+    temperature: 0.7,
+  },
+  // Bump request timeout because reasoning runs can be long.
+  { timeoutMs: 300_000 },
+);
+
+let inThinking = false;
+for await (const event of stream) {
+  const delta = event.data?.choices[0]?.delta.content;
+  if (!delta) continue;
+
+  if (typeof delta === "string") {
+    if (inThinking) {
+      process.stdout.write("\n--- /thinking ---\n");
+      inThinking = false;
+    }
+    process.stdout.write(delta);
+    continue;
+  }
+
+  for (const chunk of delta) {
+    if (chunk.type === "thinking") {
+      if (!inThinking) {
+        process.stdout.write("--- thinking ---\n");
+        inThinking = true;
+      }
+      for (const inner of chunk.thinking) {
+        if (inner.type === "text") {
+          process.stdout.write(inner.text);
+        }
+      }
+    } else if (chunk.type === "text") {
+      if (inThinking) {
+        process.stdout.write("\n--- /thinking ---\n");
+        inThinking = false;
+      }
+      process.stdout.write(chunk.text);
+    }
+  }
+}
+
+process.stdout.write("\n");


### PR DESCRIPTION
## Summary

Adds four runnable examples in `examples/src/` demonstrating `reasoningEffort` on `mistral-medium-3-5`. The SDK already supports the parameter and the `ThinkChunk` / `TextChunk` types, but there were no examples showing how to use them. TypeScript port of mistralai/client-python#511.

## Files

- `reasoning_response_shape.ts` — first stop. Calls the API once with `reasoningEffort: "high"` and once with `"none"`, then dumps the raw `message.content` so the reader can see the `ThinkChunk` / `TextChunk` JSON before consuming it.
- `reasoning.ts` — single-turn call. Iterates `message.content` and discriminates on `chunk.type === "thinking" | "text"`. Notes that `reasoningEffort: "none"` returns a plain `string`.
- `reasoning_with_streaming.ts` — the streaming version. Handles the three shapes that arrive on `delta.content`: `ThinkChunk` arrays during the thinking phase, a transition array containing both a closing `ThinkChunk` and the first `TextChunk`, and plain string fragments after thinking ends.
- `reasoning_multi_turn.ts` — 3-turn math chain (17 × 23 → × 3 → −100). Replays the assistant turn back into `messages` with `ThinkChunk`s intact and prints per-turn token usage so the cost difference is visible.

## Notes

- All examples use per-call `{ timeoutMs: 300_000 }` because reasoning runs routinely exceed the default 30s timeout.
- Model is pinned to `mistral-medium-3-5` (the model docs explicitly list as supporting `reasoningEffort`).

## Test plan

- [x] \`npx tsc --noEmit\` passes for all four files against the project's strict tsconfig.
- [x] \`npx tsx examples/src/reasoning_response_shape.ts\` — verified output matches the documented \`ThinkChunk\` / \`TextChunk\` schema; \`"none"\` returns \`string\`.
- [x] \`npx tsx examples/src/reasoning.ts\` — verified the John puzzle returns \`John is 22 years old\`.
- [x] \`npx tsx examples/src/reasoning_with_streaming.ts\` — verified the trains problem returns \`11:16:40 am\` and the thinking → final-answer transition renders cleanly.
- [x] \`npx tsx examples/src/reasoning_multi_turn.ts\` — verified the chain arrives at \`1073\`; observed totals prompt=1020, completion=608 (sum 1628).