### PR TITLE
ci: scope secrets to publish environment

### DIFF
--- a/.github/workflows/publish_alpha.yaml
+++ b/.github/workflows/publish_alpha.yaml
@@ -11,6 +11,7 @@ jobs:
   publish:
     if: github.event.inputs.confirm_publish == 'publish'
     runs-on: ubuntu-latest
+    environment: public-sdk
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0

--- a/.github/workflows/publish_alpha.yaml
+++ b/.github/workflows/publish_alpha.yaml
@@ -11,7 +11,7 @@ jobs:
   publish:
     if: github.event.inputs.confirm_publish == 'publish'
     runs-on: ubuntu-latest
-    environment: public-sdk
+    environment: publish
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0

--- a/.github/workflows/run_example_scripts.yaml
+++ b/.github/workflows/run_example_scripts.yaml
@@ -29,7 +29,7 @@ jobs:
   examples:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
-    environment: public-sdk
+    environment: publish
     steps:
       - name: Checkout code
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3

--- a/.github/workflows/run_example_scripts.yaml
+++ b/.github/workflows/run_example_scripts.yaml
@@ -11,6 +11,24 @@ on:
 jobs:
   lint:
     runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+
+      - name: Set up Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: '22'
+
+      - name: Install dependencies
+        run: npm install && npm install --prefix examples && npm install tsx
+
+      - name: Build the project
+        run: npm run build
+
+  examples:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
     environment: public-sdk
     steps:
       - name: Checkout code

--- a/.github/workflows/run_example_scripts.yaml
+++ b/.github/workflows/run_example_scripts.yaml
@@ -11,6 +11,7 @@ on:
 jobs:
   lint:
     runs-on: ubuntu-latest
+    environment: public-sdk
     steps:
       - name: Checkout code
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3


### PR DESCRIPTION
Scopes secrets to the `public-sdk` environment so secret-using jobs require approval before running.