### PR TITLE
ci: migrate SDK generation to speakeasy ci CLI

### DIFF
--- a/.github/workflows/sdk_generation_mistralai_azure_sdk.yaml
+++ b/.github/workflows/sdk_generation_mistralai_azure_sdk.yaml
@@ -14,15 +14,62 @@ permissions:
       set_version:
         description: optionally set a specific SDK version
         type: string
+      feature_branch:
+        description: "Branch for SDK changes"
+        required: false
+        type: string
+      environment:
+        description: "Environment variables (e.g., tag=branch-name)"
+        required: false
+        type: string
 jobs:
+  resolve-speakeasy-version:
+    runs-on: ubuntu-24.04
+    outputs:
+      speakeasy_version: ${{ steps.read-version.outputs.speakeasy_version }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
+
+      - name: Read Speakeasy version from workflow config
+        id: read-version
+        shell: bash
+        run: |
+          version="$(awk -F': ' '/^speakeasyVersion:/ {print $2}' .speakeasy/workflow.yaml)"
+          if [ -z "$version" ]; then
+            echo "Failed to resolve speakeasyVersion from .speakeasy/workflow.yaml" >&2
+            exit 1
+          fi
+          # Strip optional leading 'v'
+          version="${version#v}"
+          echo "speakeasy_version=$version" >> "$GITHUB_OUTPUT"
+
   generate:
-    uses: speakeasy-api/sdk-generation-action/.github/workflows/workflow-executor.yaml@a658ca0a4a9b11bbcd7d3fb4e3063fa843afabff # v15
-    with:
-      force: ${{ github.event.inputs.force }}
-      mode: pr
-      set_version: ${{ github.event.inputs.set_version }}
-      speakeasy_version: latest
-      target: mistralai-azure-sdk
-    secrets:
-      github_access_token: ${{ secrets.CLIENT_PIPELINE }}
-      speakeasy_api_key: ${{ secrets.SPEAKEASY_API_KEY }}
+    needs: resolve-speakeasy-version
+    runs-on: ubuntu-24.04
+    environment: publish
+    steps:
+      - name: Checkout
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.CLIENT_PIPELINE }}
+
+      - name: Install Speakeasy CLI
+        env:
+          VERSION: ${{ needs.resolve-speakeasy-version.outputs.speakeasy_version }}
+        run: |
+          curl -fsSL https://raw.githubusercontent.com/speakeasy-api/speakeasy/07977787cc394cb30b418a591b3332e40e209be1/install.sh | sh
+          speakeasy --version
+
+      - name: Run SDK generation
+        env:
+          INPUT_GITHUB_ACCESS_TOKEN: ${{ secrets.CLIENT_PIPELINE }}
+          SPEAKEASY_API_KEY: ${{ secrets.SPEAKEASY_API_KEY }}
+          INPUT_MODE: pr
+          INPUT_FORCE: ${{ github.event.inputs.force }}
+          INPUT_TARGET: mistralai-azure-sdk
+          INPUT_SET_VERSION: ${{ github.event.inputs.set_version }}
+          INPUT_FEATURE_BRANCH: ${{ github.event.inputs.feature_branch }}
+          INPUT_CLI_ENVIRONMENT_VARIABLES: ${{ github.event.inputs.environment }}
+        run: speakeasy ci generate

--- a/.github/workflows/sdk_generation_mistralai_gcp_sdk.yaml
+++ b/.github/workflows/sdk_generation_mistralai_gcp_sdk.yaml
@@ -14,15 +14,62 @@ permissions:
       set_version:
         description: optionally set a specific SDK version
         type: string
+      feature_branch:
+        description: "Branch for SDK changes"
+        required: false
+        type: string
+      environment:
+        description: "Environment variables (e.g., tag=branch-name)"
+        required: false
+        type: string
 jobs:
+  resolve-speakeasy-version:
+    runs-on: ubuntu-24.04
+    outputs:
+      speakeasy_version: ${{ steps.read-version.outputs.speakeasy_version }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
+
+      - name: Read Speakeasy version from workflow config
+        id: read-version
+        shell: bash
+        run: |
+          version="$(awk -F': ' '/^speakeasyVersion:/ {print $2}' .speakeasy/workflow.yaml)"
+          if [ -z "$version" ]; then
+            echo "Failed to resolve speakeasyVersion from .speakeasy/workflow.yaml" >&2
+            exit 1
+          fi
+          # Strip optional leading 'v'
+          version="${version#v}"
+          echo "speakeasy_version=$version" >> "$GITHUB_OUTPUT"
+
   generate:
-    uses: speakeasy-api/sdk-generation-action/.github/workflows/workflow-executor.yaml@a658ca0a4a9b11bbcd7d3fb4e3063fa843afabff # v15
-    with:
-      force: ${{ github.event.inputs.force }}
-      mode: pr
-      set_version: ${{ github.event.inputs.set_version }}
-      speakeasy_version: latest
-      target: mistralai-gcp-sdk
-    secrets:
-      github_access_token: ${{ secrets.CLIENT_PIPELINE }}
-      speakeasy_api_key: ${{ secrets.SPEAKEASY_API_KEY }}
+    needs: resolve-speakeasy-version
+    runs-on: ubuntu-24.04
+    environment: publish
+    steps:
+      - name: Checkout
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.CLIENT_PIPELINE }}
+
+      - name: Install Speakeasy CLI
+        env:
+          VERSION: ${{ needs.resolve-speakeasy-version.outputs.speakeasy_version }}
+        run: |
+          curl -fsSL https://raw.githubusercontent.com/speakeasy-api/speakeasy/07977787cc394cb30b418a591b3332e40e209be1/install.sh | sh
+          speakeasy --version
+
+      - name: Run SDK generation
+        env:
+          INPUT_GITHUB_ACCESS_TOKEN: ${{ secrets.CLIENT_PIPELINE }}
+          SPEAKEASY_API_KEY: ${{ secrets.SPEAKEASY_API_KEY }}
+          INPUT_MODE: pr
+          INPUT_FORCE: ${{ github.event.inputs.force }}
+          INPUT_TARGET: mistralai-gcp-sdk
+          INPUT_SET_VERSION: ${{ github.event.inputs.set_version }}
+          INPUT_FEATURE_BRANCH: ${{ github.event.inputs.feature_branch }}
+          INPUT_CLI_ENVIRONMENT_VARIABLES: ${{ github.event.inputs.environment }}
+        run: speakeasy ci generate

--- a/.github/workflows/sdk_generation_mistralai_sdk.yaml
+++ b/.github/workflows/sdk_generation_mistralai_sdk.yaml
@@ -14,15 +14,62 @@ permissions:
       set_version:
         description: optionally set a specific SDK version
         type: string
+      feature_branch:
+        description: "Branch for SDK changes"
+        required: false
+        type: string
+      environment:
+        description: "Environment variables (e.g., tag=branch-name)"
+        required: false
+        type: string
 jobs:
+  resolve-speakeasy-version:
+    runs-on: ubuntu-24.04
+    outputs:
+      speakeasy_version: ${{ steps.read-version.outputs.speakeasy_version }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
+
+      - name: Read Speakeasy version from workflow config
+        id: read-version
+        shell: bash
+        run: |
+          version="$(awk -F': ' '/^speakeasyVersion:/ {print $2}' .speakeasy/workflow.yaml)"
+          if [ -z "$version" ]; then
+            echo "Failed to resolve speakeasyVersion from .speakeasy/workflow.yaml" >&2
+            exit 1
+          fi
+          # Strip optional leading 'v'
+          version="${version#v}"
+          echo "speakeasy_version=$version" >> "$GITHUB_OUTPUT"
+
   generate:
-    uses: speakeasy-api/sdk-generation-action/.github/workflows/workflow-executor.yaml@a658ca0a4a9b11bbcd7d3fb4e3063fa843afabff # v15
-    with:
-      force: ${{ github.event.inputs.force }}
-      mode: pr
-      set_version: ${{ github.event.inputs.set_version }}
-      speakeasy_version: latest
-      target: mistralai-sdk
-    secrets:
-      github_access_token: ${{ secrets.CLIENT_PIPELINE }}
-      speakeasy_api_key: ${{ secrets.SPEAKEASY_API_KEY }}
+    needs: resolve-speakeasy-version
+    runs-on: ubuntu-24.04
+    environment: publish
+    steps:
+      - name: Checkout
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.CLIENT_PIPELINE }}
+
+      - name: Install Speakeasy CLI
+        env:
+          VERSION: ${{ needs.resolve-speakeasy-version.outputs.speakeasy_version }}
+        run: |
+          curl -fsSL https://raw.githubusercontent.com/speakeasy-api/speakeasy/07977787cc394cb30b418a591b3332e40e209be1/install.sh | sh
+          speakeasy --version
+
+      - name: Run SDK generation
+        env:
+          INPUT_GITHUB_ACCESS_TOKEN: ${{ secrets.CLIENT_PIPELINE }}
+          SPEAKEASY_API_KEY: ${{ secrets.SPEAKEASY_API_KEY }}
+          INPUT_MODE: pr
+          INPUT_FORCE: ${{ github.event.inputs.force }}
+          INPUT_TARGET: mistralai-sdk
+          INPUT_SET_VERSION: ${{ github.event.inputs.set_version }}
+          INPUT_FEATURE_BRANCH: ${{ github.event.inputs.feature_branch }}
+          INPUT_CLI_ENVIRONMENT_VARIABLES: ${{ github.event.inputs.environment }}
+        run: speakeasy ci generate

--- a/.speakeasy/workflow.yaml
+++ b/.speakeasy/workflow.yaml
@@ -1,5 +1,5 @@
 workflowVersion: 1.0.0
-speakeasyVersion: v1.761.9
+speakeasyVersion: 1.763.2
 sources:
     mistral-azure-source:
         inputs:


### PR DESCRIPTION
## Summary

Replaces Speakeasy's reusable workflow with a steps-based job invoking the `speakeasy ci generate` CLI directly. This lets the `generate` job declare `environment: publish`, gating secrets access behind the required reviewer approval.

Also bumps `speakeasyVersion` to `1.763.2`, which includes the upstream fix for the go-git push bug in `CommitAndPush` (speakeasy-api/speakeasy#2043).

## Scope

Three generation workflows updated:
- `sdk_generation_mistralai_sdk.yaml` (target `mistralai-sdk`)
- `sdk_generation_mistralai_azure_sdk.yaml` (target `mistralai-azure-sdk`)
- `sdk_generation_mistralai_gcp_sdk.yaml` (target `mistralai-gcp-sdk`)

## Validation

After merge, manually dispatch each generation workflow and confirm the run goes green end-to-end. May produce a regen PR with updated SDK output from the 1.761.9 to 1.763.2 jump, which is expected and can be reviewed + merged separately.

## Notes

This only updates the workflow YAMLs and `.speakeasy/workflow.yaml` version pin. SDK regen + lock file updates will land via the next gen workflow dispatch.
