### PR TITLE
ci: drop unneeded publish env from non-secret-using lint jobs

### DIFF
--- a/.github/workflows/run_example_scripts.yaml
+++ b/.github/workflows/run_example_scripts.yaml
@@ -11,8 +11,6 @@ on:
 jobs:
   lint:
     runs-on: ubuntu-latest
-    environment:
-      name: publish
     steps:
       - name: Checkout code
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3

--- a/.github/workflows/test_custom_code.yaml
+++ b/.github/workflows/test_custom_code.yaml
@@ -11,8 +11,6 @@ on:
 jobs:
   lint:
     runs-on: ubuntu-latest
-    environment:
-      name: publish
     steps:
       - name: Checkout code
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3


### PR DESCRIPTION
## Summary

Two workflows have a non-secret-using job pinned to `environment: publish`:
- `test_custom_code.yaml` (lint + build + unit tests)
- `run_example_scripts.yaml`'s `lint` job (build only)

Neither references any secret, so the env declaration adds no security but does cause friction:
- Forces the env approval flow on every PR
- Limits the workflow to branches whitelisted in the `publish` environment's branch policy (currently only `main`)
- Causes the lint check to fail immediately on any feature branch that is not whitelisted

This PR removes those env declarations. The `examples` job in `run_example_scripts.yaml` keeps `environment: publish` since it actually uses `MISTRAL_API_KEY`.
