### PR TITLE
chore: bump speakeasyVersion to 1.763.6

### DIFF
--- a/.speakeasy/workflow.yaml
+++ b/.speakeasy/workflow.yaml
@@ -1,5 +1,5 @@
 workflowVersion: 1.0.0
-speakeasyVersion: 1.763.2
+speakeasyVersion: 1.763.6
 sources:
     mistral-azure-source:
         inputs:


### PR DESCRIPTION
## Summary

Bumps the pinned Speakeasy CLI version from 1.763.2 to 1.763.6 in `.speakeasy/workflow.yaml`.

## Why

Picks up upstream TypeScript generator fixes shipped between 1.763.2 and 1.763.6:

- **Unhandled rejection fix in lax-mode smart primitives** (1.763.6).
- **Multi-SDK fixes** for async declarations, doc rendering, exports (1.763.3).

## Validation

Tested locally: `speakeasy run -t mistralai-sdk` at 1.763.6 completes clean on top of current main.

## What this PR does NOT do

Only bumps the pinned version. The actual SDK regeneration with the new generator will happen via the next `Generate MISTRALAI` workflow run, producing the usual regen auto-PR.