### PR TITLE
ci: switch npm publish to npm stage publish for the 3 SDK packages

### DIFF
--- a/.github/workflows/sdk_publish_mistralai_azure_sdk.yaml
+++ b/.github/workflows/sdk_publish_mistralai_azure_sdk.yaml
@@ -31,7 +31,7 @@ jobs:
 
       - name: Install dependencies
         working-directory: packages/mistralai-azure
-        run: npx -y -p npm@11.14.0 npm install --ignore-scripts --min-release-age=7
+        run: npx -y -p npm@11.15.0 npm install --ignore-scripts --min-release-age=7
 
       - name: Build package
         working-directory: packages/mistralai-azure
@@ -50,5 +50,5 @@ jobs:
             TAG="latest"
           fi
 
-          echo "Publishing under dist-tag: $TAG"
-          npm publish --tag "$TAG" --access public --provenance
+          echo "Staging under dist-tag: $TAG"
+          npm stage publish --tag "$TAG" --access public --provenance

--- a/.github/workflows/sdk_publish_mistralai_gcp_sdk.yaml
+++ b/.github/workflows/sdk_publish_mistralai_gcp_sdk.yaml
@@ -31,7 +31,7 @@ jobs:
 
       - name: Install dependencies
         working-directory: packages/mistralai-gcp
-        run: npx -y -p npm@11.14.0 npm install --ignore-scripts --min-release-age=7
+        run: npx -y -p npm@11.15.0 npm install --ignore-scripts --min-release-age=7
 
       - name: Build package
         working-directory: packages/mistralai-gcp
@@ -50,5 +50,5 @@ jobs:
             TAG="latest"
           fi
 
-          echo "Publishing under dist-tag: $TAG"
-          npm publish --tag "$TAG" --access public --provenance
+          echo "Staging under dist-tag: $TAG"
+          npm stage publish --tag "$TAG" --access public --provenance

--- a/.github/workflows/sdk_publish_mistralai_sdk.yaml
+++ b/.github/workflows/sdk_publish_mistralai_sdk.yaml
@@ -41,7 +41,7 @@ jobs:
           registry-url: "https://registry.npmjs.org"
 
       - name: Install dependencies
-        run: npx -y -p npm@11.14.0 npm install --ignore-scripts --min-release-age=7
+        run: npx -y -p npm@11.15.0 npm install --ignore-scripts --min-release-age=7
 
       - name: Build package
         run: npm run build
@@ -60,5 +60,5 @@ jobs:
             TAG="latest"
           fi
 
-          echo "Publishing under dist-tag: $TAG"
-          npm publish --tag "$TAG" --access public --provenance
+          echo "Staging under dist-tag: $TAG"
+          npm stage publish --tag "$TAG" --access public --provenance


### PR DESCRIPTION
## Summary

Adopts [npm staged publishing](https://docs.npmjs.com/staged-publishing) (introduced in npm 11.15.0, May 2026) for the 3 public SDK packages:
- `@mistralai/mistralai`
- `@mistralai/mistralai-azure`
- `@mistralai/mistralai-gcp`

Releases are uploaded to npm's staging area and require explicit manual approval (web or `npm stage approve <id>`) before they become installable.

## Notes

- Bumps the pinned npm version from `11.14.0` to `11.15.0` (minimum version that ships `npm stage`).