### PR TITLE
ci: pin npm 11.15.0 for stage publish command

### DIFF
--- a/.github/workflows/sdk_publish_mistralai_azure_sdk.yaml
+++ b/.github/workflows/sdk_publish_mistralai_azure_sdk.yaml
@@ -51,4 +51,4 @@ jobs:
           fi
 
           echo "Staging under dist-tag: $TAG"
-          npm stage publish --tag "$TAG" --access public --provenance
+          npx -y -p npm@11.15.0 npm stage publish --tag "$TAG" --access public --provenance

--- a/.github/workflows/sdk_publish_mistralai_gcp_sdk.yaml
+++ b/.github/workflows/sdk_publish_mistralai_gcp_sdk.yaml
@@ -51,4 +51,4 @@ jobs:
           fi
 
           echo "Staging under dist-tag: $TAG"
-          npm stage publish --tag "$TAG" --access public --provenance
+          npx -y -p npm@11.15.0 npm stage publish --tag "$TAG" --access public --provenance

--- a/.github/workflows/sdk_publish_mistralai_sdk.yaml
+++ b/.github/workflows/sdk_publish_mistralai_sdk.yaml
@@ -61,4 +61,4 @@ jobs:
           fi
 
           echo "Staging under dist-tag: $TAG"
-          npm stage publish --tag "$TAG" --access public --provenance
+          npx -y -p npm@11.15.0 npm stage publish --tag "$TAG" --access public --provenance


### PR DESCRIPTION
## Summary

The `npm stage publish` command requires npm 11.15.0+ but Node 24's bundled npm is 11.13.0. Calling `npm stage publish` directly fails with `Unknown command: \"stage\"`.

## Fix

Wrap the publish call with `npx -y -p npm@11.15.0 ...`, matching the existing pattern already used in the install step.

Applied to all 3 publish workflows:
- `sdk_publish_mistralai_sdk.yaml`
- `sdk_publish_mistralai_azure_sdk.yaml`
- `sdk_publish_mistralai_gcp_sdk.yaml`

## Validation

Reproduced the failure live, the npm CLI explicitly reports `Unknown command: \"stage\"` when 11.13.0 is invoked. Pinning to 11.15.0 via `npx` resolves it.