### PR TITLE
fix(examples): use canonical CMS asset URL for chat-with-image example

### DIFF
--- a/examples/src/async_chat_with_image_no_streaming.ts
+++ b/examples/src/async_chat_with_image_no_streaming.ts
@@ -17,7 +17,7 @@ const chatResponse = await client.chat.complete({
         {
           type: "image_url",
           imageUrl:
-            "https://mistral.ai/_next/image?url=https%3A%2F%2Fcms.mistral.ai%2Fassets%2Fce1514ab-62f9-4825-a20b-298f2497c536&w=3840&q=75",
+            "https://cms.mistral.ai/assets/ce1514ab-62f9-4825-a20b-298f2497c536",
         },
       ],
     },


### PR DESCRIPTION
The chat-with-image example used a `mistral.ai/_next/image` proxy URL that now returns 404, so the image can't be fetched and the example fails with a 400. Point at the image asset directly instead.

```diff
-            "https://mistral.ai/_next/image?url=...&w=3840&q=75",
+            "https://cms.mistral.ai/assets/ce1514ab-62f9-4825-a20b-298f2497c536",
```