### PR TITLE
Add telemetry autoconfiguration

### DIFF
--- a/src/extra/observability/index.ts
+++ b/src/extra/observability/index.ts
@@ -1,2 +1,19 @@
-export { registerTracerProvider, traceAsync } from "./otel.js";
+export { traceAsync } from "./otel.js";
 export { MISTRAL_SDK_OTEL_TRACER_NAME } from "./otel.js";
+export { getRegisteredTracerProvider, registerTracerProvider } from "./provider.js";
+export {
+  configureTelemetry,
+  configureTelemetryForHook,
+  MISTRAL_OTLP_TRACES_ENDPOINT_ENV,
+  MISTRAL_SDK_TELEMETRY_ENV,
+  MISTRAL_TELEMETRY_BASE_URL,
+  MISTRAL_TELEMETRY_ENDPOINT,
+  MISTRAL_TELEMETRY_TRACES_PATH,
+  setTracerProvider,
+  TELEMETRY_PROVIDER_DEDICATED,
+  TELEMETRY_PROVIDER_GLOBAL,
+  TelemetryConfigurationError,
+  type TelemetryProvider,
+  type TelemetryProviderMode,
+  type TelemetrySetting,
+} from "./telemetry.js";

--- a/src/extra/observability/otel.ts
+++ b/src/extra/observability/otel.ts
@@ -22,22 +22,16 @@ import {
   formatOutputMessage,
   formatToolDefinition,
 } from "./formatting.js";
+import { getRegisteredTracerProvider } from "./provider.js";
 import { accumulateChunksToResponseDict, parseSseChunks } from "./streaming.js";
 
 export type { Context, Span, Tracer };
 export { semConvAttributes };
+export { getRegisteredTracerProvider, registerTracerProvider } from "./provider.js";
 
 export const OTEL_SERVICE_NAME = "mistralai_sdk";
 export const MISTRAL_SDK_OTEL_TRACER_NAME = `${OTEL_SERVICE_NAME}_tracer`;
 const MISTRAL_AGENT_TRACE_PUBLIC_ATTRIBUTE = "agent.trace.public";
-let registeredTracerProvider: TracerProvider | undefined;
-
-/**
- * Route SDK tracing spans to a specific OpenTelemetry tracer provider.
- */
-export function registerTracerProvider(tracerProvider?: TracerProvider): void {
-  registeredTracerProvider = tracerProvider;
-}
 
 // Safe check for environment variable in both Node.js and browser
 const getDebugTracing = (): boolean => {
@@ -433,8 +427,13 @@ export function enrichSpanFromResponse(
  * return a NoOp tracer, effectively disabling tracing. Once the application
  * sets up a real TracerProvider, subsequent spans will be recorded.
  */
-export function getOrCreateOtelTracer(): Tracer {
-  const tracerProvider = registeredTracerProvider ?? trace.getTracerProvider();
+export function getOrCreateOtelTracer(
+  provider?: TracerProvider,
+  options: { useRegisteredProvider?: boolean } = {},
+): Tracer {
+  const tracerProvider = provider ??
+    (options.useRegisteredProvider === false ? undefined : getRegisteredTracerProvider()) ??
+    trace.getTracerProvider();
   return tracerProvider.getTracer(MISTRAL_SDK_OTEL_TRACER_NAME);
 }
 

--- a/src/extra/observability/provider.ts
+++ b/src/extra/observability/provider.ts
@@ -1,0 +1,17 @@
+import type { TracerProvider } from "@opentelemetry/api";
+
+let registeredTracerProvider: TracerProvider | undefined;
+
+/**
+ * Route SDK tracing spans to a specific OpenTelemetry tracer provider.
+ */
+export function registerTracerProvider(tracerProvider?: TracerProvider): void {
+  registeredTracerProvider = tracerProvider;
+}
+
+/**
+ * Returns the currently registered tracer provider, if any.
+ */
+export function getRegisteredTracerProvider(): TracerProvider | undefined {
+  return registeredTracerProvider;
+}

--- a/src/extra/observability/telemetry.ts
+++ b/src/extra/observability/telemetry.ts
@@ -1,0 +1,524 @@
+import type { TracerProvider } from "@opentelemetry/api";
+
+import type { SDKOptions } from "../../lib/config.js";
+import type { SecurityState } from "../../lib/security.js";
+import { OTEL_SERVICE_NAME } from "./otel.js";
+import { getRegisteredTracerProvider } from "./provider.js";
+
+export const MISTRAL_SDK_TELEMETRY_ENV = "MISTRAL_SDK_TELEMETRY";
+export const MISTRAL_TELEMETRY_BASE_URL = "https://api.mistral.ai";
+export const MISTRAL_TELEMETRY_TRACES_PATH = "/telemetry/v1/traces";
+export const MISTRAL_TELEMETRY_ENDPOINT = createTelemetryEndpoint(MISTRAL_TELEMETRY_BASE_URL);
+export const MISTRAL_OTLP_TRACES_ENDPOINT_ENV = "MISTRAL_OTLP_TRACES_ENDPOINT";
+export const TELEMETRY_PROVIDER_DEDICATED = "dedicated";
+export const TELEMETRY_PROVIDER_GLOBAL = "global";
+
+const DISABLED_VALUE = "false";
+const PROVIDER_VALUES = [
+  TELEMETRY_PROVIDER_DEDICATED,
+  TELEMETRY_PROVIDER_GLOBAL,
+] as const;
+
+export type TelemetryProviderMode = typeof PROVIDER_VALUES[number];
+export type TelemetrySetting = boolean | string | null | undefined;
+export type TelemetryProvider = TelemetryProviderMode | TracerProvider;
+
+export type ManagedTelemetryTracerProvider = TracerProvider & {
+  shutdown?: () => void | Promise<void>;
+  forceFlush?: () => void | Promise<void>;
+};
+
+export type TelemetryCapableTracingHook = {
+  readonly _mistralTracingHook: true;
+  tracerProvider: TracerProvider | undefined;
+  _autoTelemetryProvider: ManagedTelemetryTracerProvider | undefined;
+  _telemetryInitialization: Promise<boolean> | undefined;
+  _telemetryConfigurationVersion: number;
+  _telemetryAutoDisabled: boolean;
+  _telemetryUseGlobalProvider: boolean;
+};
+
+type TelemetryContext = {
+  baseURL?: string | URL | null | undefined;
+  options?: SDKOptions | undefined;
+  resolvedSecurity?: SecurityState | null | undefined;
+};
+
+type ClientWithHooks = {
+  _baseURL?: string | URL | null | undefined;
+  _options?: (SDKOptions & { hooks?: { beforeRequestHooks?: unknown[] } }) | undefined;
+};
+
+export type ModuleLoader = (specifier: string) => Promise<Record<string, unknown>>;
+
+export type CreateTelemetryTracerProviderOptions = {
+  apiKey: string | null | undefined;
+  baseURL?: string | URL | null | undefined;
+  moduleLoader?: ModuleLoader | undefined;
+};
+
+type CreateTelemetryTracerProvider = (
+  options: CreateTelemetryTracerProviderOptions,
+) => Promise<ManagedTelemetryTracerProvider>;
+
+type ConfigureTelemetryForHookOptions = {
+  telemetry?: TelemetrySetting;
+  replaceExisting?: boolean | undefined;
+  createTelemetryTracerProvider?: CreateTelemetryTracerProvider;
+};
+
+type OtelResource = { merge?: (resource: unknown) => unknown };
+type OtelResourceConstructor = (new (attributes: Record<string, string>) => OtelResource) & {
+  default?: () => OtelResource;
+};
+
+export class TelemetryConfigurationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "TelemetryConfigurationError";
+  }
+}
+
+export async function configureTelemetry(
+  client: ClientWithHooks,
+  provider: TelemetryProvider = TELEMETRY_PROVIDER_DEDICATED,
+): Promise<boolean> {
+  const hook = getTracingHook(client);
+
+  if (typeof provider === "string") {
+    const providerMode = resolveProviderMode(provider);
+    if (providerMode === TELEMETRY_PROVIDER_GLOBAL) {
+      return useGlobalTracerProvider(hook, { replaceExisting: true });
+    }
+
+    return configureTelemetryForHook(
+      hook,
+      { baseURL: client._baseURL, options: client._options },
+      { telemetry: providerMode, replaceExisting: true },
+    );
+  }
+
+  markTelemetryConfigurationChanged(hook);
+  await attachCustomTracerProvider(hook, provider);
+  return true;
+}
+
+export async function setTracerProvider(
+  client: ClientWithHooks,
+  provider: TracerProvider,
+): Promise<boolean> {
+  return configureTelemetry(client, provider);
+}
+
+export async function configureTelemetryForHook(
+  hook: TelemetryCapableTracingHook,
+  context: TelemetryContext,
+  options: ConfigureTelemetryForHookOptions = {},
+): Promise<boolean> {
+  const telemetryOverride = options.telemetry;
+  const hasTelemetryOverride = telemetryOverride != null;
+  const replaceExisting = options.replaceExisting === true;
+  if (!hasTelemetryOverride && hasConfiguredAutoTelemetry(hook)) {
+    return true;
+  }
+  if (!hasTelemetryOverride && hook._telemetryAutoDisabled) {
+    return false;
+  }
+
+  const providerMode = hasTelemetryOverride
+    ? resolveTelemetryMode(telemetryOverride)
+    : resolveMistralTelemetryEnv();
+
+  if (hook._telemetryInitialization !== undefined) {
+    if (!replaceExisting && providerMode === TELEMETRY_PROVIDER_DEDICATED) {
+      return hook._telemetryInitialization;
+    }
+    try {
+      await hook._telemetryInitialization;
+    } catch {
+      // Allow explicit disable/global/replacement calls to proceed after a
+      // failed in-flight auto-initialization.
+    }
+  }
+
+  if (providerMode == null) {
+    markTelemetryConfigurationChanged(hook);
+    await shutdownTelemetryProvider(hook);
+    markAutoTelemetryDisabled(hook);
+    return false;
+  }
+
+  if (providerMode === TELEMETRY_PROVIDER_GLOBAL) {
+    return useGlobalTracerProvider(hook, {
+      replaceExisting: replaceExisting || hasTelemetryOverride,
+    });
+  }
+
+  if (hook._autoTelemetryProvider !== undefined) {
+    return true;
+  }
+
+  if (hook.tracerProvider !== undefined) {
+    if (!replaceExisting) {
+      return false;
+    }
+    hook.tracerProvider = undefined;
+  }
+
+  if (getRegisteredTracerProvider() !== undefined && !replaceExisting) {
+    return false;
+  }
+
+  const configurationVersion = markTelemetryConfigurationChanged(hook);
+  const initialization = initializeTelemetryProvider(
+    hook,
+    context,
+    options,
+    configurationVersion,
+  );
+  hook._telemetryInitialization = initialization;
+  try {
+    return await initialization;
+  } finally {
+    if (hook._telemetryInitialization === initialization) {
+      hook._telemetryInitialization = undefined;
+    }
+  }
+}
+
+async function initializeTelemetryProvider(
+  hook: TelemetryCapableTracingHook,
+  context: TelemetryContext,
+  options: ConfigureTelemetryForHookOptions,
+  configurationVersion: number,
+): Promise<boolean> {
+  const createProvider = options.createTelemetryTracerProvider ?? _createTelemetryTracerProvider;
+  const provider = await createProvider({
+    apiKey: await resolveApiKey(context),
+    baseURL: context.baseURL ?? context.options?.serverURL,
+  });
+
+  if (hook._telemetryConfigurationVersion !== configurationVersion) {
+    await provider.shutdown?.();
+    return false;
+  }
+
+  await attachTelemetryProvider(hook, provider);
+  return true;
+}
+
+export async function _createTelemetryTracerProvider(
+  options: CreateTelemetryTracerProviderOptions,
+): Promise<ManagedTelemetryTracerProvider> {
+  if (options.apiKey == null || options.apiKey === "") {
+    throw new TelemetryConfigurationError(
+      "Mistral telemetry requires an API key. Pass apiKey to the client or set MISTRAL_API_KEY.",
+    );
+  }
+
+  const moduleLoader = options.moduleLoader ?? loadModule;
+  let sdkTraceBase: Record<string, unknown>;
+  let otlpExporterModule: Record<string, unknown>;
+  let resourcesModule: Record<string, unknown>;
+  try {
+    [sdkTraceBase, otlpExporterModule, resourcesModule] = await Promise.all([
+      moduleLoader("@opentelemetry/sdk-trace-base"),
+      moduleLoader("@opentelemetry/exporter-trace-otlp-http"),
+      moduleLoader("@opentelemetry/resources"),
+    ]);
+  } catch {
+    throw new TelemetryConfigurationError(
+      "Mistral telemetry requires optional OpenTelemetry SDK/exporter dependencies. " +
+        "Install @opentelemetry/sdk-trace-base, @opentelemetry/exporter-trace-otlp-http, " +
+        "and @opentelemetry/resources with your package manager.",
+    );
+  }
+
+  const BasicTracerProvider = requireExportConstructor(
+    sdkTraceBase,
+    "BasicTracerProvider",
+    "@opentelemetry/sdk-trace-base",
+  );
+  const BatchSpanProcessor = requireExportConstructor(
+    sdkTraceBase,
+    "BatchSpanProcessor",
+    "@opentelemetry/sdk-trace-base",
+  );
+  const OTLPTraceExporter = requireExportConstructor(
+    otlpExporterModule,
+    "OTLPTraceExporter",
+    "@opentelemetry/exporter-trace-otlp-http",
+  );
+
+  const exporter = new OTLPTraceExporter({
+    url: resolveMistralTelemetryEndpoint(options.baseURL),
+    headers: { Authorization: asBearerToken(options.apiKey) },
+  });
+  const spanProcessor = new BatchSpanProcessor(exporter);
+  const resource = createResource(resourcesModule, {
+    "service.name": OTEL_SERVICE_NAME,
+  });
+
+  const provider = new BasicTracerProvider({ resource }) as ManagedTelemetryTracerProvider & {
+    addSpanProcessor?: (processor: unknown) => void;
+  };
+  if (typeof provider.addSpanProcessor === "function") {
+    provider.addSpanProcessor(spanProcessor);
+    return provider;
+  }
+
+  return new BasicTracerProvider({
+    resource,
+    spanProcessors: [spanProcessor],
+  }) as ManagedTelemetryTracerProvider;
+}
+
+function getTracingHook(client: ClientWithHooks): TelemetryCapableTracingHook {
+  const hooks = client._options?.hooks;
+  const beforeRequestHooks = hooks?.beforeRequestHooks;
+  if (!Array.isArray(beforeRequestHooks)) {
+    throw new Error("Cannot configure telemetry: SDK hooks not initialised.");
+  }
+
+  const hook = beforeRequestHooks.find(isTelemetryCapableTracingHook);
+  if (hook === undefined) {
+    throw new Error("Cannot configure telemetry: TracingHook not found in the client's hooks.");
+  }
+  return hook;
+}
+
+function isTelemetryCapableTracingHook(
+  hook: unknown,
+): hook is TelemetryCapableTracingHook {
+  return Boolean(
+    hook &&
+      typeof hook === "object" &&
+      (hook as { _mistralTracingHook?: unknown })._mistralTracingHook === true,
+  );
+}
+
+function resolveTelemetryMode(value: boolean | string): TelemetryProviderMode | null {
+  if (typeof value === "boolean") {
+    return value ? TELEMETRY_PROVIDER_DEDICATED : null;
+  }
+
+  const normalized = value.trim().toLowerCase();
+  switch (normalized) {
+    case TELEMETRY_PROVIDER_DEDICATED:
+      return TELEMETRY_PROVIDER_DEDICATED;
+    case TELEMETRY_PROVIDER_GLOBAL:
+      return TELEMETRY_PROVIDER_GLOBAL;
+    case DISABLED_VALUE:
+      return null;
+  }
+
+  throw new TelemetryConfigurationError(
+    `Invalid telemetry setting ${JSON.stringify(value)}. Expected one of: dedicated, false, global.`,
+  );
+}
+
+function resolveProviderMode(value: string): TelemetryProviderMode {
+  const normalized = value.trim().toLowerCase();
+  switch (normalized) {
+    case TELEMETRY_PROVIDER_DEDICATED:
+      return TELEMETRY_PROVIDER_DEDICATED;
+    case TELEMETRY_PROVIDER_GLOBAL:
+      return TELEMETRY_PROVIDER_GLOBAL;
+  }
+
+  throw new TelemetryConfigurationError(
+    `Invalid telemetry provider ${JSON.stringify(value)}. Expected one of: dedicated, global.`,
+  );
+}
+
+function resolveMistralTelemetryEnv(): TelemetryProviderMode | null {
+  const envValue = readEnv(MISTRAL_SDK_TELEMETRY_ENV);
+  if (envValue == null || envValue === "") {
+    return null;
+  }
+
+  try {
+    return resolveTelemetryMode(envValue);
+  } catch {
+    throw new TelemetryConfigurationError(
+      `Invalid ${MISTRAL_SDK_TELEMETRY_ENV}=${JSON.stringify(envValue)}. ` +
+        "Expected one of: dedicated, false, global.",
+    );
+  }
+}
+
+async function resolveApiKey(context: TelemetryContext): Promise<string> {
+  const authHeader = context.resolvedSecurity?.headers?.["Authorization"];
+  if (authHeader) {
+    return authHeader;
+  }
+
+  const apiKey = await resolveApiKeySource(context.options?.apiKey);
+  if (apiKey) {
+    return apiKey;
+  }
+
+  const envApiKey = readEnv("MISTRAL_API_KEY");
+  if (envApiKey) {
+    return envApiKey;
+  }
+
+  throw new TelemetryConfigurationError(
+    "Mistral telemetry requires an API key. Pass apiKey to the client or set MISTRAL_API_KEY.",
+  );
+}
+
+async function resolveApiKeySource(
+  source: SDKOptions["apiKey"],
+): Promise<string | undefined> {
+  if (source == null) {
+    return undefined;
+  }
+  return typeof source === "function" ? source() : source;
+}
+
+function resolveMistralTelemetryEndpoint(baseURL?: string | URL | null): string {
+  const endpoint = readEnv(MISTRAL_OTLP_TRACES_ENDPOINT_ENV)?.trim();
+  if (endpoint) {
+    return endpoint;
+  }
+  if (baseURL != null && `${baseURL}`.trim() !== "") {
+    return createTelemetryEndpoint(baseURL);
+  }
+  return MISTRAL_TELEMETRY_ENDPOINT;
+}
+
+function createTelemetryEndpoint(baseURL: string | URL): string {
+  return new URL(MISTRAL_TELEMETRY_TRACES_PATH, baseURL).toString();
+}
+
+async function attachTelemetryProvider(
+  hook: TelemetryCapableTracingHook,
+  provider: ManagedTelemetryTracerProvider,
+): Promise<void> {
+  await shutdownTelemetryProvider(hook);
+  hook.tracerProvider = provider;
+  hook._autoTelemetryProvider = provider;
+  hook._telemetryUseGlobalProvider = false;
+  hook._telemetryAutoDisabled = false;
+}
+
+function hasConfiguredAutoTelemetry(hook: TelemetryCapableTracingHook): boolean {
+  return hook._autoTelemetryProvider !== undefined || hook._telemetryUseGlobalProvider;
+}
+
+function markAutoTelemetryDisabled(hook: TelemetryCapableTracingHook): void {
+  hook._telemetryUseGlobalProvider = false;
+  hook._telemetryAutoDisabled = true;
+}
+
+function markTelemetryConfigurationChanged(hook: TelemetryCapableTracingHook): number {
+  hook._telemetryConfigurationVersion += 1;
+  return hook._telemetryConfigurationVersion;
+}
+
+async function attachCustomTracerProvider(
+  hook: TelemetryCapableTracingHook,
+  provider: TracerProvider,
+): Promise<void> {
+  await shutdownTelemetryProvider(hook);
+  hook.tracerProvider = provider;
+  hook._telemetryUseGlobalProvider = false;
+  hook._telemetryAutoDisabled = false;
+}
+
+async function useGlobalTracerProvider(
+  hook: TelemetryCapableTracingHook,
+  options: { replaceExisting: boolean },
+): Promise<boolean> {
+  if (
+    hook.tracerProvider !== undefined &&
+    hook._autoTelemetryProvider === undefined &&
+    !options.replaceExisting
+  ) {
+    return false;
+  }
+
+  markTelemetryConfigurationChanged(hook);
+  await shutdownTelemetryProvider(hook);
+  hook.tracerProvider = undefined;
+  hook._telemetryUseGlobalProvider = true;
+  hook._telemetryAutoDisabled = true;
+  return true;
+}
+
+async function shutdownTelemetryProvider(
+  hook: TelemetryCapableTracingHook,
+): Promise<void> {
+  const provider = hook._autoTelemetryProvider;
+  if (provider === undefined) {
+    return;
+  }
+
+  hook._autoTelemetryProvider = undefined;
+  if (hook.tracerProvider === provider) {
+    hook.tracerProvider = undefined;
+  }
+  await provider.shutdown?.();
+}
+
+function asBearerToken(apiKey: string): string {
+  return apiKey.toLowerCase().startsWith("bearer ") ? apiKey : `Bearer ${apiKey}`;
+}
+
+function readEnv(name: string): string | undefined {
+  try {
+    const denoEnv = (globalThis as { Deno?: { env?: { get?: (key: string) => string | undefined } } })
+      .Deno?.env;
+    const denoValue = denoEnv?.get?.(name);
+    if (denoValue !== undefined) {
+      return denoValue;
+    }
+  } catch {
+    // Ignore unavailable Deno permissions.
+  }
+
+  try {
+    return (globalThis as { process?: { env?: Record<string, string | undefined> } })
+      .process?.env?.[name];
+  } catch {
+    return undefined;
+  }
+}
+
+async function loadModule(specifier: string): Promise<Record<string, unknown>> {
+  return await import(specifier) as Record<string, unknown>;
+}
+
+function requireExportConstructor(
+  moduleExports: Record<string, unknown>,
+  exportName: string,
+  moduleName: string,
+): new (...args: unknown[]) => unknown {
+  const value = moduleExports[exportName];
+  if (typeof value !== "function") {
+    throw new TelemetryConfigurationError(
+      `Mistral telemetry expected ${moduleName} to export ${exportName}.`,
+    );
+  }
+  return value as new (...args: unknown[]) => unknown;
+}
+
+function createResource(
+  moduleExports: Record<string, unknown>,
+  attributes: Record<string, string>,
+): unknown {
+  const resourceFromAttributes = moduleExports["resourceFromAttributes"];
+  if (typeof resourceFromAttributes === "function") {
+    return resourceFromAttributes(attributes);
+  }
+
+  const Resource = moduleExports["Resource"] as OtelResourceConstructor | undefined;
+  if (typeof Resource !== "function") {
+    return { attributes };
+  }
+
+  const resource = new Resource(attributes);
+  const defaultResource = Resource.default?.();
+  return defaultResource?.merge?.(resource) ?? resource;
+}

--- a/src/hooks/tracing.ts
+++ b/src/hooks/tracing.ts
@@ -1,4 +1,6 @@
-import type { Context, Span, Tracer } from "@opentelemetry/api";
+import type { Context, Span, Tracer, TracerProvider } from "@opentelemetry/api";
+import { getRegisteredTracerProvider } from "../extra/observability/provider.js";
+import type { ManagedTelemetryTracerProvider } from "../extra/observability/telemetry.js";
 import { HTTPClient } from "../lib/http.js";
 import {
   AfterErrorContext,
@@ -13,8 +15,10 @@ import {
 } from "./types.js";
 
 type ObservabilityModule = typeof import("../extra/observability/otel.js");
+type TelemetryModule = typeof import("../extra/observability/telemetry.js");
 
 let observabilityModule: ObservabilityModule | null | undefined;
+let telemetryModule: TelemetryModule | null | undefined;
 
 async function getObservabilityModule(): Promise<ObservabilityModule | null> {
   if (observabilityModule !== undefined) {
@@ -31,6 +35,21 @@ async function getObservabilityModule(): Promise<ObservabilityModule | null> {
   return observabilityModule;
 }
 
+async function getTelemetryModule(): Promise<TelemetryModule | null> {
+  if (telemetryModule !== undefined) {
+    return telemetryModule;
+  }
+
+  try {
+    telemetryModule = await import("../extra/observability/telemetry.js");
+  } catch {
+    // OpenTelemetry is an optional peer; without it, telemetry is a no-op.
+    telemetryModule = null;
+  }
+
+  return telemetryModule;
+}
+
 export const TRACING_SPAN_KEY = "_tracingSpan";
 export const TRACING_BODY_KEY = "_tracingBody";
 export const TRACING_TRACER_KEY = "_tracingTracer";
@@ -40,6 +59,12 @@ export type TracingContext = HookContext & {
   [TRACING_BODY_KEY]?: string | null;
   [TRACING_TRACER_KEY]?: Tracer;
 };
+
+function clearTracingContext(ctx: TracingContext): void {
+  delete ctx[TRACING_TRACER_KEY];
+  delete ctx[TRACING_SPAN_KEY];
+  delete ctx[TRACING_BODY_KEY];
+}
 
 // Runs the actual HTTP send inside the GenAI span context so lower-level
 // fetch/http auto-instrumentation parents its spans correctly.
@@ -88,6 +113,13 @@ class TracingHTTPClient extends HTTPClient {
 
 export class TracingHook implements SDKInitHook, BeforeRequestHook, AfterSuccessHook, AfterErrorHook {
   readonly #requestContexts = new WeakMap<Request, Context>();
+  readonly _mistralTracingHook = true;
+  tracerProvider: TracerProvider | undefined = undefined;
+  _autoTelemetryProvider: ManagedTelemetryTracerProvider | undefined = undefined;
+  _telemetryInitialization: Promise<boolean> | undefined = undefined;
+  _telemetryConfigurationVersion = 0;
+  _telemetryAutoDisabled = false;
+  _telemetryUseGlobalProvider = false;
 
   sdkInit(opts: SDKInitOptions): SDKInitOptions {
     return {
@@ -106,7 +138,23 @@ export class TracingHook implements SDKInitHook, BeforeRequestHook, AfterSuccess
       return request;
     }
 
-    const tracer = observability.getOrCreateOtelTracer();
+    const telemetry = await getTelemetryModule();
+    const telemetryConfigured = telemetry
+      ? await telemetry.configureTelemetryForHook(this, hookCtx)
+      : false;
+    const shouldTrace = telemetryConfigured ||
+      this.tracerProvider !== undefined ||
+      this._telemetryUseGlobalProvider ||
+      getRegisteredTracerProvider() !== undefined;
+
+    if (!shouldTrace) {
+      clearTracingContext(ctx);
+      return request;
+    }
+
+    const tracer = observability.getOrCreateOtelTracer(this.tracerProvider, {
+      useRegisteredProvider: !this._telemetryUseGlobalProvider,
+    });
 
     const { request: tracedRequest, span, body } = await observability.getTracedRequestAndSpan(
       tracer,

--- a/tests/extra/observability/customProvider.test.ts
+++ b/tests/extra/observability/customProvider.test.ts
@@ -4,6 +4,7 @@ import {
   getOrCreateOtelTracer,
   registerTracerProvider,
 } from "../../../src/extra/observability/otel.js";
+import { MISTRAL_SDK_TELEMETRY_ENV } from "../../../src/extra/observability/telemetry.js";
 import {
   TracingHook,
   type TracingContext,
@@ -37,8 +38,19 @@ function createHookContext(): TracingContext {
   } as TracingContext;
 }
 
+const ORIGINAL_MISTRAL_SDK_TELEMETRY = process.env[MISTRAL_SDK_TELEMETRY_ENV];
+
+beforeEach(() => {
+  delete process.env[MISTRAL_SDK_TELEMETRY_ENV];
+});
+
 afterEach(() => {
   registerTracerProvider();
+  if (ORIGINAL_MISTRAL_SDK_TELEMETRY === undefined) {
+    delete process.env[MISTRAL_SDK_TELEMETRY_ENV];
+  } else {
+    process.env[MISTRAL_SDK_TELEMETRY_ENV] = ORIGINAL_MISTRAL_SDK_TELEMETRY;
+  }
 });
 
 describe("getOrCreateOtelTracer", () => {
@@ -66,6 +78,21 @@ describe("getOrCreateOtelTracer", () => {
     expect((tracer as any).label).toBe("registered");
     spy.mockRestore();
   });
+
+  test("can bypass registered provider for explicit global mode", () => {
+    const registeredTracer = createMockTracer("registered");
+    const globalTracer = createMockTracer("global");
+    registerTracerProvider(createMockTracerProvider(registeredTracer));
+    const spy = vi
+      .spyOn(trace, "getTracerProvider")
+      .mockReturnValue(createMockTracerProvider(globalTracer));
+
+    const tracer = getOrCreateOtelTracer(undefined, { useRegisteredProvider: false });
+
+    expect(spy).toHaveBeenCalled();
+    expect((tracer as any).label).toBe("global");
+    spy.mockRestore();
+  });
 });
 
 describe("TracingHook with registered TracerProvider", () => {
@@ -81,7 +108,41 @@ describe("TracingHook with registered TracerProvider", () => {
     expect((ctx[TRACING_TRACER_KEY] as any).label).toBe("registered");
   });
 
-  test("beforeRequest falls back to global provider when no provider is registered", async () => {
+  test("beforeRequest uses global provider when env telemetry opts in", async () => {
+    const hook = new TracingHook();
+    const globalTracer = createMockTracer("global");
+    const spy = vi
+      .spyOn(trace, "getTracerProvider")
+      .mockReturnValue(createMockTracerProvider(globalTracer));
+
+    process.env[MISTRAL_SDK_TELEMETRY_ENV] = "global";
+    const ctx = createHookContext();
+    await hook.beforeRequest(ctx, createChatRequest());
+
+    expect(spy).toHaveBeenCalled();
+    expect((ctx[TRACING_TRACER_KEY] as any).label).toBe("global");
+    spy.mockRestore();
+  });
+
+  test("beforeRequest global telemetry bypasses registered provider", async () => {
+    const hook = new TracingHook();
+    const registeredTracer = createMockTracer("registered");
+    const globalTracer = createMockTracer("global");
+    registerTracerProvider(createMockTracerProvider(registeredTracer));
+    const spy = vi
+      .spyOn(trace, "getTracerProvider")
+      .mockReturnValue(createMockTracerProvider(globalTracer));
+
+    process.env[MISTRAL_SDK_TELEMETRY_ENV] = "global";
+    const ctx = createHookContext();
+    await hook.beforeRequest(ctx, createChatRequest());
+
+    expect(spy).toHaveBeenCalled();
+    expect((ctx[TRACING_TRACER_KEY] as any).label).toBe("global");
+    spy.mockRestore();
+  });
+
+  test("beforeRequest does not use global provider without Mistral telemetry", async () => {
     const hook = new TracingHook();
     const globalTracer = createMockTracer("global");
     const spy = vi
@@ -91,8 +152,8 @@ describe("TracingHook with registered TracerProvider", () => {
     const ctx = createHookContext();
     await hook.beforeRequest(ctx, createChatRequest());
 
-    expect(spy).toHaveBeenCalled();
-    expect((ctx[TRACING_TRACER_KEY] as any).label).toBe("global");
+    expect(spy).not.toHaveBeenCalled();
+    expect(ctx[TRACING_TRACER_KEY]).toBeUndefined();
     spy.mockRestore();
   });
 });

--- a/tests/extra/observability/telemetry.test.ts
+++ b/tests/extra/observability/telemetry.test.ts
@@ -1,0 +1,378 @@
+import { trace, type Span, type TracerProvider } from "@opentelemetry/api";
+
+import { Mistral } from "../../../src/index.js";
+import {
+  configureTelemetry,
+  configureTelemetryForHook,
+  MISTRAL_OTLP_TRACES_ENDPOINT_ENV,
+  MISTRAL_SDK_TELEMETRY_ENV,
+  MISTRAL_TELEMETRY_ENDPOINT,
+  setTracerProvider,
+  TelemetryConfigurationError,
+  _createTelemetryTracerProvider,
+} from "../../../src/extra/observability/telemetry.js";
+import { TracingHook } from "../../../src/hooks/tracing.js";
+import type { HookContext } from "../../../src/hooks/types.js";
+
+type FakeProvider = TracerProvider & {
+  shutdownCalled: boolean;
+  shutdown: () => void;
+};
+
+function createSpan(): Span {
+  const span = {
+    spanContext: () => ({ traceId: "", spanId: "", traceFlags: 0 }),
+    setAttribute: () => span,
+    setAttributes: () => span,
+    addEvent: () => span,
+    addLink: () => span,
+    addLinks: () => span,
+    setStatus: () => span,
+    updateName: () => span,
+    end: () => undefined,
+    isRecording: () => false,
+    recordException: () => undefined,
+  } as Span;
+  return span;
+}
+
+function createProvider(): FakeProvider {
+  const provider = {
+    shutdownCalled: false,
+    getTracer: () => ({
+      startSpan: () => createSpan(),
+      startActiveSpan: () => undefined as never,
+    }),
+    shutdown() {
+      provider.shutdownCalled = true;
+    },
+  } as FakeProvider;
+  return provider;
+}
+
+function createTelemetryModuleLoader(exporterInstances: Array<{ config: unknown }>) {
+  return vi.fn(async (specifier: string) => {
+    if (specifier === "@opentelemetry/sdk-trace-base") {
+      return {
+        BasicTracerProvider: class {
+          spanProcessors: unknown[] = [];
+
+          constructor(public config: unknown) {}
+
+          addSpanProcessor(processor: unknown) {
+            this.spanProcessors.push(processor);
+          }
+
+          getTracer = vi.fn();
+          shutdown = vi.fn();
+        },
+        BatchSpanProcessor: class {
+          constructor(public exporter: unknown) {}
+        },
+      };
+    }
+    if (specifier === "@opentelemetry/exporter-trace-otlp-http") {
+      return {
+        OTLPTraceExporter: class {
+          constructor(public config: unknown) {
+            exporterInstances.push(this);
+          }
+        },
+      };
+    }
+    if (specifier === "@opentelemetry/resources") {
+      return {
+        resourceFromAttributes: (attributes: Record<string, string>) => ({ attributes }),
+      };
+    }
+    throw new Error(`Unexpected module ${specifier}`);
+  });
+}
+
+function createContext(
+  options: HookContext["options"] = { apiKey: "test-key" },
+): HookContext {
+  return {
+    operationID: "chat_completion_v1",
+    baseURL: "https://api.mistral.ai",
+    oAuth2Scopes: null,
+    retryConfig: { strategy: "none" },
+    resolvedSecurity: null,
+    options,
+  } as HookContext;
+}
+
+function createClient(apiKey: string | undefined = "test-key"): Mistral {
+  return new Mistral(apiKey === undefined ? {} : { apiKey });
+}
+
+function getTestTracingHook(client: Mistral): TracingHook {
+  return client._options.hooks!.beforeRequestHooks
+    .find((candidate: unknown) => candidate instanceof TracingHook) as TracingHook;
+}
+
+async function withEnv<T>(
+  env: Record<string, string | undefined>,
+  fn: () => T | Promise<T>,
+): Promise<T> {
+  const previous: Record<string, string | undefined> = {};
+  for (const key of Object.keys(env)) {
+    previous[key] = process.env[key];
+  }
+
+  try {
+    for (const [key, value] of Object.entries(env)) {
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+    return await fn();
+  } finally {
+    for (const [key, value] of Object.entries(previous)) {
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+  }
+}
+
+describe("configureTelemetryForHook", () => {
+  test("defaults to disabled when Mistral telemetry env is absent", async () => {
+    await withEnv({ [MISTRAL_SDK_TELEMETRY_ENV]: undefined }, async () => {
+      const hook = new TracingHook();
+      const createTelemetryTracerProvider = vi.fn(async () => createProvider());
+
+      const configured = await configureTelemetryForHook(hook, createContext(), {
+        createTelemetryTracerProvider,
+      });
+
+      expect(configured).toBe(false);
+      expect(createTelemetryTracerProvider).not.toHaveBeenCalled();
+      expect(hook.tracerProvider).toBeUndefined();
+      expect(hook._telemetryAutoDisabled).toBe(true);
+    });
+  });
+
+  test("MISTRAL_SDK_TELEMETRY=dedicated attaches an SDK-owned provider", async () => {
+    await withEnv({ [MISTRAL_SDK_TELEMETRY_ENV]: "dedicated" }, async () => {
+      const hook = new TracingHook();
+      const provider = createProvider();
+      const createTelemetryTracerProvider = vi.fn(async () => provider);
+
+      const configured = await configureTelemetryForHook(hook, createContext(), {
+        createTelemetryTracerProvider,
+      });
+
+      expect(configured).toBe(true);
+      expect(createTelemetryTracerProvider).toHaveBeenCalledWith({
+        apiKey: "test-key",
+        baseURL: "https://api.mistral.ai",
+      });
+      expect(hook.tracerProvider).toBe(provider);
+    });
+  });
+
+  test("MISTRAL_SDK_TELEMETRY=false disables telemetry", async () => {
+    await withEnv({ [MISTRAL_SDK_TELEMETRY_ENV]: "false" }, async () => {
+      const hook = new TracingHook();
+      const createTelemetryTracerProvider = vi.fn(async () => createProvider());
+
+      const configured = await configureTelemetryForHook(hook, createContext(), {
+        createTelemetryTracerProvider,
+      });
+
+      expect(configured).toBe(false);
+      expect(createTelemetryTracerProvider).not.toHaveBeenCalled();
+      expect(hook.tracerProvider).toBeUndefined();
+    });
+  });
+
+  test("MISTRAL_SDK_TELEMETRY=global uses global provider mode", async () => {
+    await withEnv({ [MISTRAL_SDK_TELEMETRY_ENV]: "global" }, async () => {
+      const hook = new TracingHook();
+      const createTelemetryTracerProvider = vi.fn(async () => createProvider());
+
+      const configured = await configureTelemetryForHook(hook, createContext(), {
+        createTelemetryTracerProvider,
+      });
+
+      expect(configured).toBe(true);
+      expect(createTelemetryTracerProvider).not.toHaveBeenCalled();
+      expect(hook.tracerProvider).toBeUndefined();
+      expect(hook._telemetryUseGlobalProvider).toBe(true);
+    });
+  });
+
+  test("MISTRAL_SDK_TELEMETRY=dedicated creates an SDK-owned provider even when a global provider exists", async () => {
+    await withEnv({ [MISTRAL_SDK_TELEMETRY_ENV]: "dedicated" }, async () => {
+      const globalProviderSpy = vi
+        .spyOn(trace, "getTracerProvider")
+        .mockReturnValue(createProvider());
+      const hook = new TracingHook();
+      const provider = createProvider();
+      const createTelemetryTracerProvider = vi.fn(async () => provider);
+
+      try {
+        const configured = await configureTelemetryForHook(hook, createContext(), {
+          createTelemetryTracerProvider,
+        });
+
+        expect(configured).toBe(true);
+        expect(globalProviderSpy).not.toHaveBeenCalled();
+        expect(createTelemetryTracerProvider).toHaveBeenCalledTimes(1);
+        expect(hook.tracerProvider).toBe(provider);
+        expect(hook._telemetryUseGlobalProvider).toBe(false);
+      } finally {
+        globalProviderSpy.mockRestore();
+      }
+    });
+  });
+
+  test("shares in-flight SDK-owned provider initialization", async () => {
+    await withEnv({ [MISTRAL_SDK_TELEMETRY_ENV]: "dedicated" }, async () => {
+      const hook = new TracingHook();
+      const provider = createProvider();
+      let resolveProvider!: () => void;
+      const providerReady = new Promise<void>((resolve) => {
+        resolveProvider = resolve;
+      });
+      const createTelemetryTracerProvider = vi.fn(async () => {
+        await providerReady;
+        return provider;
+      });
+
+      const first = configureTelemetryForHook(hook, createContext(), {
+        createTelemetryTracerProvider,
+      });
+      const second = configureTelemetryForHook(hook, createContext(), {
+        createTelemetryTracerProvider,
+      });
+
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(createTelemetryTracerProvider).toHaveBeenCalledTimes(1);
+
+      resolveProvider();
+
+      await expect(Promise.all([first, second])).resolves.toEqual([true, true]);
+      expect(createTelemetryTracerProvider).toHaveBeenCalledTimes(1);
+      expect(hook.tracerProvider).toBe(provider);
+      expect(hook._telemetryInitialization).toBeUndefined();
+      expect(provider.shutdownCalled).toBe(false);
+    });
+  });
+
+  test("invalid Mistral telemetry env raises a configuration error", async () => {
+    await withEnv({ [MISTRAL_SDK_TELEMETRY_ENV]: "true" }, async () => {
+      const hook = new TracingHook();
+
+      await expect(configureTelemetryForHook(hook, createContext())).rejects.toThrow(
+        TelemetryConfigurationError,
+      );
+    });
+  });
+});
+
+describe("configureTelemetry", () => {
+  test("explicit global mode clears auto provider", async () => {
+    const client = createClient();
+    const hook = getTestTracingHook(client);
+    const provider = createProvider();
+    hook.tracerProvider = provider;
+    hook._autoTelemetryProvider = provider;
+
+    const configured = await configureTelemetry(client, "global");
+
+    expect(configured).toBe(true);
+    expect(provider.shutdownCalled).toBe(true);
+    expect(hook.tracerProvider).toBeUndefined();
+    expect(hook._telemetryUseGlobalProvider).toBe(true);
+  });
+
+  test("custom provider replaces auto provider without shutting down the custom provider", async () => {
+    const client = createClient();
+    const hook = getTestTracingHook(client);
+    const autoProvider = createProvider();
+    const customProvider = createProvider();
+    hook.tracerProvider = autoProvider;
+    hook._autoTelemetryProvider = autoProvider;
+
+    const configured = await configureTelemetry(client, customProvider);
+
+    expect(configured).toBe(true);
+    expect(autoProvider.shutdownCalled).toBe(true);
+    expect(customProvider.shutdownCalled).toBe(false);
+    expect(hook.tracerProvider).toBe(customProvider);
+  });
+
+  test("setTracerProvider is a compatibility wrapper", async () => {
+    const client = createClient();
+    const hook = getTestTracingHook(client);
+    const provider = createProvider();
+
+    await setTracerProvider(client, provider);
+
+    expect(hook.tracerProvider).toBe(provider);
+  });
+});
+
+describe("_createTelemetryTracerProvider", () => {
+  test("uses the Mistral endpoint and bearer auth", async () => {
+    const exporterInstances: Array<{ config: unknown }> = [];
+    const moduleLoader = createTelemetryModuleLoader(exporterInstances);
+
+    await _createTelemetryTracerProvider({
+      apiKey: "test-key",
+      moduleLoader,
+    });
+
+    expect(exporterInstances).toHaveLength(1);
+    expect(exporterInstances[0]?.config).toEqual({
+      url: MISTRAL_TELEMETRY_ENDPOINT,
+      headers: { Authorization: "Bearer test-key" },
+    });
+  });
+
+  test("uses the configured base URL with the telemetry traces path", async () => {
+    const exporterInstances: Array<{ config: unknown }> = [];
+    const moduleLoader = createTelemetryModuleLoader(exporterInstances);
+
+    await _createTelemetryTracerProvider({
+      apiKey: "test-key",
+      baseURL: "http://mistral.test/api",
+      moduleLoader,
+    });
+
+    expect(exporterInstances).toHaveLength(1);
+    expect(exporterInstances[0]?.config).toEqual({
+      url: "http://mistral.test/telemetry/v1/traces",
+      headers: { Authorization: "Bearer test-key" },
+    });
+  });
+
+  test("MISTRAL_OTLP_TRACES_ENDPOINT overrides the configured base URL endpoint", async () => {
+    await withEnv(
+      { [MISTRAL_OTLP_TRACES_ENDPOINT_ENV]: "http://collector:4318/v1/traces" },
+      async () => {
+        const exporterInstances: Array<{ config: unknown }> = [];
+        const moduleLoader = createTelemetryModuleLoader(exporterInstances);
+
+        await _createTelemetryTracerProvider({
+          apiKey: "test-key",
+          baseURL: "http://mistral.test",
+          moduleLoader,
+        });
+
+        expect(exporterInstances).toHaveLength(1);
+        expect(exporterInstances[0]?.config).toEqual({
+          url: "http://collector:4318/v1/traces",
+          headers: { Authorization: "Bearer test-key" },
+        });
+      },
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add telemetry autoconfiguration helpers for dedicated, global, and custom tracer providers
- wire tracing hooks to opt in via environment or explicit configureTelemetry calls
- keep dedicated telemetry on an SDK-owned provider and add focused observability tests

https://github.com/mistralai/client-python/pull/553, for TS

## Usage
Enable SDK-owned telemetry with an environment variable before making requests:

```bash
export MISTRAL_SDK_TELEMETRY=dedicated
```

```ts
import { Mistral } from "@mistralai/mistralai";

const client = new Mistral({ apiKey: process.env["MISTRAL_API_KEY"] });

await client.chat.complete({
  model: "mistral-small-latest",
  messages: [{ role: "user", content: "Hello" }],
});
```

Or configure telemetry explicitly on a client:

```ts
import { Mistral } from "@mistralai/mistralai";
import { configureTelemetry } from "@mistralai/mistralai/extra/observability";

const client = new Mistral({ apiKey: process.env["MISTRAL_API_KEY"] });

await configureTelemetry(client); // dedicated SDK-owned provider

await client.chat.complete({
  model: "mistral-small-latest",
  messages: [{ role: "user", content: "Hello" }],
});
```

Use `MISTRAL_SDK_TELEMETRY=global` or `await configureTelemetry(client, "global")` to emit spans through the application's existing OpenTelemetry global provider.

## Validation

Added tests, and manually tested with: [manual_telemetry_smoke.ts](https://github.com/user-attachments/files/29243510/manual_telemetry_smoke.ts)

Set your `MISTRAL_API_KEY`:

```sh
$ pnpm add @opentelemetry/sdk-trace-base @opentelemetry/exporter-trace-otlp-http @opentelemetry/resources
Packages: +9
+++++++++
Progress: resolved 46, reused 13, downloaded 9, added 9, done

dependencies:
+ @opentelemetry/exporter-trace-otlp-http 0.219.0
+ @opentelemetry/resources 2.8.0
+ @opentelemetry/sdk-trace-base 2.8.0

Done in 1.7s using pnpm v10.26.1
$ MISTRAL_SDK_TELEMETRY=dedicated node scripts/manual_telemetry_smoke.ts
Telemetry smoke test
- setup: env
- telemetry: dedicated
- endpoint: https://api.mistral.ai/telemetry/v1/traces
- model: mistral-small-latest
- chat response: telemetry smoke test ok

$  MISTRAL_SDK_TELEMETRY=global node scripts/manual_telemetry_smoke.ts
- global terminal tracer provider registered: true
Telemetry smoke test
- setup: env
- telemetry: global
- exporter: terminal
- model: mistral-small-latest

[otel export]
{
  "name": "chat mistral-small-latest",
  "status": {
    "code": 1
  },
  "attributes": {
    "agent.trace.public": "",
    "gen_ai.input.messages": "[{\"role\":\"user\",\"parts\":[{\"type\":\"text\",\"content\":\"Reply with exactly: telemetry smoke test ok\"}]}]",
    "gen_ai.operation.name": "chat",
    "gen_ai.output.messages": "[{\"role\":\"assistant\",\"parts\":[{\"type\":\"text\",\"content\":\"telemetry smoke test ok\"}],\"finish_reason\":\"stop\"}]",
    "gen_ai.provider.name": "mistral_ai",
    "gen_ai.request.model": "mistral-small-latest",
    "gen_ai.response.finish_reasons": [
      "stop"
    ],
    "gen_ai.response.id": "6fad45e6c7d74c58a736c4db284a1898",
    "gen_ai.response.model": "mistral-small-latest",
    "gen_ai.usage.input_tokens": 24,
    "gen_ai.usage.output_tokens": 6,
    "http.request.method": "POST",
    "http.response.status_code": 200,
    "server.address": "api.mistral.ai",
    "server.port": 443,
    "url.full": "https://api.mistral.ai/v1/chat/completions"
  },
  "events": []
}
- chat response: telemetry smoke test ok
- global terminal telemetry provider exported spans on span.end()
Done.
```
