### PR TITLE
fix(observability): handle structured streaming content chunks

### DIFF
--- a/src/extra/observability/streaming.ts
+++ b/src/extra/observability/streaming.ts
@@ -15,6 +15,7 @@ import {
   CompletionChunk,
   completionChunkFromJSON,
 } from "../../models/components/completionchunk.js";
+import { ContentChunk } from "../../models/components/contentchunk.js";
 import {
   UsageInfo,
   UsageInfo$outboundSchema,
@@ -125,9 +126,7 @@ export function accumulateChunksToResponseDict(
       if (typeof delta.role === "string") {
         msg.role = delta.role;
       }
-      if (typeof delta.content === "string" && delta.content) {
-        msg.content += delta.content;
-      }
+      msg.content += extractOutputText(delta.content);
       if (typeof choice.finishReason === "string") {
         accumulated.finish_reason = choice.finishReason;
       }
@@ -171,4 +170,19 @@ export function accumulateChunksToResponseDict(
     result["usage"] = UsageInfo$outboundSchema.parse(usage);
   }
   return result;
+}
+
+function extractOutputText(
+  content: string | Array<ContentChunk> | null | undefined
+): string {
+  if (typeof content === "string") {
+    return content;
+  }
+  if (!Array.isArray(content)) {
+    return "";
+  }
+  return content
+    .filter((block): block is ContentChunk & { type: "text" } => block.type === "text")
+    .map((block) => block.text)
+    .join("");
 }

--- a/tests/extra/observability/streaming.test.ts
+++ b/tests/extra/observability/streaming.test.ts
@@ -88,6 +88,30 @@ describe("accumulateChunksToResponseDict", () => {
     ]);
   });
 
+  test("accumulates content when delta.content is an array of ContentChunk objects", () => {
+    const arrayContentChunk: Record<string, unknown> = {
+      id: "id-1",
+      model: "m",
+      choices: [{
+        index: 0,
+        delta: {
+          role: "assistant",
+          content: [{ type: "text", text: "Bonjour" }],
+        },
+        finish_reason: null,
+      }],
+    };
+    const chunks = parseSseChunks(toSse([
+      arrayContentChunk,
+      chunk({ content: " monde", finishReason: "stop" }),
+    ]));
+    const result = accumulateChunksToResponseDict(chunks);
+    expect(result.choices).toEqual([{
+      message: { role: "assistant", content: "Bonjour monde" },
+      finish_reason: "stop",
+    }]);
+  });
+
   test("handles empty chunks", () => {
     expect(accumulateChunksToResponseDict([])).toEqual({ id: undefined, model: undefined, choices: [] });
   });


### PR DESCRIPTION
porting this fix https://github.com/mistralai/client-python/pull/565 to the TS sdk as it's the same issue
reproduced and fixed 