### PR TITLE
Add client-aware telemetry tracer getter

### DIFF
--- a/src/extra/observability/index.ts
+++ b/src/extra/observability/index.ts
@@ -4,6 +4,7 @@ export { getRegisteredTracerProvider, registerTracerProvider } from "./provider.
 export {
   configureTelemetry,
   configureTelemetryForHook,
+  getTelemetryTracer,
   MISTRAL_OTLP_TRACES_ENDPOINT_ENV,
   MISTRAL_SDK_TELEMETRY_ENV,
   MISTRAL_TELEMETRY_BASE_URL,
@@ -17,3 +18,5 @@ export {
   type TelemetryProviderMode,
   type TelemetrySetting,
 } from "./telemetry.js";
+
+export type { Tracer, TracerOptions, TracerProvider } from "@opentelemetry/api";

--- a/src/extra/observability/telemetry.ts
+++ b/src/extra/observability/telemetry.ts
@@ -1,4 +1,9 @@
-import type { TracerProvider } from "@opentelemetry/api";
+import {
+  trace,
+  type Tracer,
+  type TracerOptions,
+  type TracerProvider,
+} from "@opentelemetry/api";
 
 import type { SDKOptions } from "../../lib/config.js";
 import type { SecurityState } from "../../lib/security.js";
@@ -108,6 +113,20 @@ export async function setTracerProvider(
   provider: TracerProvider,
 ): Promise<boolean> {
   return configureTelemetry(client, provider);
+}
+
+export function getTelemetryTracer(
+  client: ClientWithHooks,
+  name: string,
+  version?: string,
+  options?: TracerOptions,
+): Tracer {
+  const hook = getTracingHook(client);
+  const providerMode = resolveMistralTelemetryEnv();
+  return getClientTracerProvider(
+    hook,
+    providerMode === TELEMETRY_PROVIDER_GLOBAL,
+  ).getTracer(name, version, options);
 }
 
 export async function configureTelemetryForHook(
@@ -295,6 +314,24 @@ function isTelemetryCapableTracingHook(
       typeof hook === "object" &&
       (hook as { _mistralTracingHook?: unknown })._mistralTracingHook === true,
   );
+}
+
+function getClientTracerProvider(
+  hook: TelemetryCapableTracingHook,
+  usesGlobalProvider: boolean,
+): TracerProvider {
+  if (hook.tracerProvider !== undefined) {
+    return hook.tracerProvider;
+  }
+
+  if (!usesGlobalProvider && !hook._telemetryUseGlobalProvider) {
+    const registeredProvider = getRegisteredTracerProvider();
+    if (registeredProvider !== undefined) {
+      return registeredProvider;
+    }
+  }
+
+  return trace.getTracerProvider();
 }
 
 function resolveTelemetryMode(value: boolean | string): TelemetryProviderMode | null {

--- a/tests/extra/observability/telemetry.test.ts
+++ b/tests/extra/observability/telemetry.test.ts
@@ -1,6 +1,16 @@
-import { trace, type Span, type TracerProvider } from "@opentelemetry/api";
+import {
+  trace,
+  type Span,
+  type Tracer,
+  type TracerOptions,
+  type TracerProvider,
+} from "@opentelemetry/api";
 
 import { Mistral } from "../../../src/index.js";
+import {
+  getTelemetryTracer,
+  registerTracerProvider,
+} from "../../../src/extra/observability/index.js";
 import {
   configureTelemetry,
   configureTelemetryForHook,
@@ -18,6 +28,8 @@ type FakeProvider = TracerProvider & {
   shutdownCalled: boolean;
   shutdown: () => void;
 };
+
+type NamedTracer = Tracer & { label: string };
 
 function createSpan(): Span {
   const span = {
@@ -48,6 +60,28 @@ function createProvider(): FakeProvider {
     },
   } as FakeProvider;
   return provider;
+}
+
+function createNamedTracer(label: string): NamedTracer {
+  return {
+    label,
+    startSpan: () => createSpan(),
+    startActiveSpan: () => undefined as never,
+  } as NamedTracer;
+}
+
+function createNamedProvider(tracer: Tracer): TracerProvider {
+  return {
+    getTracer: vi.fn((
+      _name: string,
+      _version?: string,
+      _options?: TracerOptions,
+    ) => tracer),
+  } as TracerProvider;
+}
+
+function expectTracerLabel(tracer: Tracer, label: string): void {
+  expect((tracer as NamedTracer).label).toBe(label);
 }
 
 function createTelemetryModuleLoader(exporterInstances: Array<{ config: unknown }>) {
@@ -139,6 +173,11 @@ async function withEnv<T>(
     }
   }
 }
+
+afterEach(() => {
+  registerTracerProvider(undefined);
+  vi.restoreAllMocks();
+});
 
 describe("configureTelemetryForHook", () => {
   test("defaults to disabled when Mistral telemetry env is absent", async () => {
@@ -317,6 +356,104 @@ describe("configureTelemetry", () => {
     await setTracerProvider(client, provider);
 
     expect(hook.tracerProvider).toBe(provider);
+  });
+
+});
+
+describe("getTelemetryTracer", () => {
+  test("uses the provider configured on the client", async () => {
+    const client = createClient();
+    const clientTracer = createNamedTracer("client");
+    const registeredTracer = createNamedTracer("registered");
+    const provider = createNamedProvider(clientTracer);
+    const registeredProvider = createNamedProvider(registeredTracer);
+    const globalProviderSpy = vi.spyOn(trace, "getTracerProvider");
+    registerTracerProvider(registeredProvider);
+
+    await configureTelemetry(client, provider);
+
+    const tracer = getTelemetryTracer(client, "my-agent");
+
+    expectTracerLabel(tracer, "client");
+    expect(provider.getTracer).toHaveBeenCalledWith("my-agent", undefined, undefined);
+    expect(registeredProvider.getTracer).not.toHaveBeenCalled();
+    expect(globalProviderSpy).not.toHaveBeenCalled();
+  });
+
+  test("explicit global provider mode bypasses the registered provider", async () => {
+    const client = createClient();
+    const registeredTracer = createNamedTracer("registered");
+    const globalTracer = createNamedTracer("global");
+    const registeredProvider = createNamedProvider(registeredTracer);
+    const globalProvider = createNamedProvider(globalTracer);
+    registerTracerProvider(registeredProvider);
+    vi.spyOn(trace, "getTracerProvider").mockReturnValue(globalProvider);
+
+    await configureTelemetry(client, "global");
+
+    const tracer = getTelemetryTracer(client, "my-agent");
+
+    expectTracerLabel(tracer, "global");
+    expect(registeredProvider.getTracer).not.toHaveBeenCalled();
+    expect(globalProvider.getTracer).toHaveBeenCalledWith("my-agent", undefined, undefined);
+  });
+
+  test("env global mode bypasses the registered provider before configuration", async () => {
+    await withEnv({ [MISTRAL_SDK_TELEMETRY_ENV]: "global" }, async () => {
+      const client = createClient();
+      const registeredTracer = createNamedTracer("registered");
+      const globalTracer = createNamedTracer("global");
+      const registeredProvider = createNamedProvider(registeredTracer);
+      const globalProvider = createNamedProvider(globalTracer);
+      registerTracerProvider(registeredProvider);
+      vi.spyOn(trace, "getTracerProvider").mockReturnValue(globalProvider);
+
+      const tracer = getTelemetryTracer(client, "my-agent");
+
+      expectTracerLabel(tracer, "global");
+      expect(registeredProvider.getTracer).not.toHaveBeenCalled();
+      expect(globalProvider.getTracer).toHaveBeenCalledWith("my-agent", undefined, undefined);
+    });
+  });
+
+  test("falls back to the registered provider when no client provider is configured", () => {
+    const client = createClient();
+    const registeredTracer = createNamedTracer("registered");
+    const registeredProvider = createNamedProvider(registeredTracer);
+    const globalProviderSpy = vi.spyOn(trace, "getTracerProvider");
+    registerTracerProvider(registeredProvider);
+
+    const tracer = getTelemetryTracer(client, "my-agent");
+
+    expectTracerLabel(tracer, "registered");
+    expect(registeredProvider.getTracer).toHaveBeenCalledWith("my-agent", undefined, undefined);
+    expect(globalProviderSpy).not.toHaveBeenCalled();
+  });
+
+  test("falls back to the global provider when no client or registered provider is configured", () => {
+    const client = createClient();
+    const globalTracer = createNamedTracer("global");
+    const globalProvider = createNamedProvider(globalTracer);
+    vi.spyOn(trace, "getTracerProvider").mockReturnValue(globalProvider);
+
+    const tracer = getTelemetryTracer(client, "my-agent");
+
+    expectTracerLabel(tracer, "global");
+    expect(globalProvider.getTracer).toHaveBeenCalledWith("my-agent", undefined, undefined);
+  });
+
+  test("passes custom tracer name, version, and options to the selected provider", async () => {
+    const client = createClient();
+    const clientTracer = createNamedTracer("client");
+    const provider = createNamedProvider(clientTracer);
+    const options = { schemaUrl: "https://schema.test/v1" };
+
+    await configureTelemetry(client, provider);
+
+    const tracer = getTelemetryTracer(client, "my-agent", "1.2.3", options);
+
+    expectTracerLabel(tracer, "client");
+    expect(provider.getTracer).toHaveBeenCalledWith("my-agent", "1.2.3", options);
   });
 });
 


### PR DESCRIPTION
## Summary
- Add getTelemetryTracer(client, name, version?, options?) to the observability public surface
- Resolve tracers from the same client-aware provider source as SDK request tracing
- Preserve explicit global telemetry mode by bypassing registered providers when configured via configureTelemetry or env

## Usage
```ts
import { Mistral } from "@mistralai/mistralai";
import {
  configureTelemetry,
  getTelemetryTracer,
} from "@mistralai/mistralai/extra/observability";

const client = new Mistral({ apiKey: process.env["MISTRAL_API_KEY"] ?? "" });

await configureTelemetry(client);

const tracer = getTelemetryTracer(client, "my-agent");

await tracer.startActiveSpan("invoke_agent", async (span) => {
  try {
    const toolResult = await runToolCall();

    return await client.chat.complete({
      model: "mistral-large-latest",
      messages: [
        { role: "user", content: `Tool returned: ${toolResult}` },
      ],
    });
  } finally {
    span.end();
  }
});
```

## Tests
- pnpm --dir tests test -- extra/observability/telemetry.test.ts
- pnpm --dir tests test -- extra/observability/customProvider.test.ts
- pnpm --dir tests test -- extra/observability
- pnpm run build
- pnpm run lint