### PR TITLE
feat(observability): client-side redaction of PII/secrets in telemetry spans

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Mistral AI API: Our Chat Completion and Embeddings APIs specification. Create yo
   * [Authentication](#authentication)
   * [Standalone functions](#standalone-functions)
   * [Debugging](#debugging)
+  * [Telemetry & Observability](#telemetry-observability)
 * [Development](#development)
   * [Contributions](#contributions)
 
@@ -1355,6 +1356,135 @@ You can also enable a default debug logger by setting an environment variable `M
 <!-- End Debugging [debug] -->
 
 <!-- Placeholder for Future Speakeasy SDK Sections -->
+
+## Telemetry & Observability
+
+The SDK can emit [OpenTelemetry](https://opentelemetry.io/) traces for the API calls it makes (chat, agents, embeddings, OCR, …), following the
+[GenAI semantic conventions](https://opentelemetry.io/docs/specs/semconv/gen-ai/).
+Spans capture the operation, model, token usage, and — unless redacted — the input/output messages and tool calls. Telemetry is **opt-in** and lives in the `@mistralai/mistralai/extra/observability` module.
+
+### Installation
+
+Dedicated mode loads the OpenTelemetry SDK and OTLP exporter on demand. Install them alongside the client:
+
+```bash
+npm install @opentelemetry/sdk-trace-base @opentelemetry/exporter-trace-otlp-http @opentelemetry/resources
+```
+
+### Enabling telemetry
+
+Either set an environment variable before creating the client:
+
+```bash
+export MISTRAL_SDK_TELEMETRY=dedicated   # dedicated | global | false
+```
+
+or configure it in code:
+
+```typescript
+import { Mistral } from "@mistralai/mistralai";
+import { configureTelemetry } from "@mistralai/mistralai/extra/observability";
+
+const client = new Mistral({ apiKey: process.env["MISTRAL_API_KEY"] });
+
+// Dedicated mode (default): the SDK creates and owns an OTLP exporter that ships
+// spans to the Mistral telemetry endpoint. Spans are redacted before export.
+await configureTelemetry(client);
+
+const response = await client.chat.complete({
+  model: "mistral-small-latest",
+  messages: [{ role: "user", content: "Hello!" }],
+});
+```
+
+### Provider modes
+
+`configureTelemetry(client, provider)` selects where spans go and who owns the export pipeline:
+
+| `provider` | Who owns the exporter | Where spans go | Redaction |
+| ---------- | --------------------- | -------------- | --------- |
+| `"dedicated"` (default) | The SDK | Mistral telemetry endpoint | Applied automatically |
+| `"global"` | Your application | Your global OpenTelemetry provider | **Not** applied — you need to wrap your own exporter |
+| a `TracerProvider` | Your application | The provider you pass | **Not** applied — you need to wrap your own exporter |
+
+In `global`/custom modes your application owns the pipeline, so the `redaction` option is ignored (a warning is logged). Wrap your own exporter with `RedactingSpanExporter` to redact spans there:
+
+```typescript
+import { trace } from "@opentelemetry/api";
+import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-http";
+import { BasicTracerProvider, BatchSpanProcessor } from "@opentelemetry/sdk-trace-base";
+import { Mistral } from "@mistralai/mistralai";
+import { configureTelemetry, RedactingSpanExporter } from "@mistralai/mistralai/extra/observability";
+
+const provider = new BasicTracerProvider({
+  spanProcessors: [
+    new BatchSpanProcessor(new RedactingSpanExporter(new OTLPTraceExporter())),
+  ],
+});
+trace.setGlobalTracerProvider(provider);
+
+const client = new Mistral({ apiKey: process.env["MISTRAL_API_KEY"] });
+
+// SDK spans now flow through your global provider (already redacted above).
+await configureTelemetry(client, "global");
+```
+
+### Redaction
+
+In dedicated mode, redaction is on by default. Control it with the `redaction` option, which also accepts any of the reusable policies from `@mistralai/mistralai/extra/observability`:
+
+```typescript
+import { AttributeRedactionPolicy } from "@mistralai/mistralai/extra/observability";
+
+await configureTelemetry(client);                                                            // default policy (regex)
+await configureTelemetry(client, "dedicated", { redaction: new AttributeRedactionPolicy() }); // very conservative key-oriented policy
+await configureTelemetry(client, "dedicated", { redaction: false });                          // disabled - no redaction
+await configureTelemetry(client, "dedicated", {                                               // custom callback to control how attributes get redacted
+  redaction: (key, value) => (key.includes("email") ? undefined : value),
+});
+```
+
+| Policy | Strategy | Trade-off |
+| ------ | -------- | --------- |
+| `RegexRedactionPolicy` (default, `redaction: true`) | Content-oriented: keeps keys and structure, redacts matched substrings (secret tokens plus PII — emails, card-like sequences, IPv4). | Redacts most sensitive data while preserving observability value; may miss free-form PII or secrets not in the pattern set. |
+| `AttributeRedactionPolicy` | Key-oriented: redacts whole values for sensitive keys (explicit set, fragment match, or non-primitive value), then scans kept values for secret token patterns. | Very conservative, but erases most prompt/response content. |
+| `CallbackRedactionPolicy` (`redaction: <callback>`) | Your `(key, value) => value \| undefined` masker per attribute; return `undefined` to drop the attribute. | Full control; you own the logic. |
+
+The built-in defaults are exported as constants, so you can extend them instead of replacing them wholesale:
+
+```typescript
+import {
+  AttributeRedactionPolicy,
+  DEFAULT_PII_SECRET_PATTERNS,
+  DEFAULT_SENSITIVE_ATTRIBUTE_KEYS,
+  RegexRedactionPolicy,
+  configureTelemetry,
+} from "@mistralai/mistralai/extra/observability";
+
+// Content-oriented: add a custom secret pattern to the default set.
+await configureTelemetry(client, "dedicated", {
+  redaction: new RegexRedactionPolicy([...DEFAULT_PII_SECRET_PATTERNS, /\bacme-[a-z0-9]{16}\b/g]),
+});
+
+// Key-oriented: mask an extra application attribute on top of the defaults.
+await configureTelemetry(client, "dedicated", {
+  redaction: new AttributeRedactionPolicy({
+    sensitiveKeys: new Set([...DEFAULT_SENSITIVE_ATTRIBUTE_KEYS, "app.customer.email"]),
+  }),
+});
+```
+
+*Note: the `RedactingSpanExporter` primitive is reusable by any OpenTelemetry application, independent of the Mistral client.*
+
+### Environment variables
+
+| Variable | Description | Default |
+| -------- | ----------- | ------- |
+| `MISTRAL_SDK_TELEMETRY` | Auto-enable telemetry: `dedicated`, `global`, or `false`. | unset (disabled) |
+| `MISTRAL_OTLP_TRACES_ENDPOINT` | Override the OTLP traces endpoint used in dedicated mode. | `https://api.mistral.ai/telemetry/v1/traces` |
+| `MISTRAL_API_KEY` | Used as the bearer token for the dedicated-mode exporter. | — |
+
+Runnable examples live in [`examples/src/observability`](/examples/src/observability).
 
 # Development
 

--- a/examples/package.json
+++ b/examples/package.json
@@ -5,7 +5,7 @@
   "description": "",
   "main": "main.js",
   "scripts": {
-    "script": "tsx --env-file=.env",
+    "script": "tsx --preserve-symlinks --env-file=.env",
     "chat-streaming": "npm run script -- ./src/chat_streaming.ts",
     "gcp": "npm run script -- ./src/gcp/async_chat_no_streaming.ts",
     "azure": "npm run script -- ./src/azure/async_chat_no_streaming.ts",
@@ -20,6 +20,10 @@
     "@mistralai/mistralai": "file:../",
     "@mistralai/mistralai-azure": "file:../packages/mistralai-azure",
     "@mistralai/mistralai-gcp": "file:../packages/mistralai-gcp",
+    "@opentelemetry/api": "^1.9.0",
+    "@opentelemetry/exporter-trace-otlp-http": "^0.220.0",
+    "@opentelemetry/resources": "^2.9.0",
+    "@opentelemetry/sdk-trace-base": "^2.9.0",
     "yargs": "^17.0.0"
   },
   "devDependencies": {

--- a/examples/src/observability/dedicated_telemetry.ts
+++ b/examples/src/observability/dedicated_telemetry.ts
@@ -1,0 +1,33 @@
+/**
+ * Dedicated telemetry mode.
+ *
+ * The SDK creates and owns an OTLP exporter that ships spans to the Mistral
+ * telemetry endpoint. Spans are redacted before export.
+ */
+
+import { Mistral } from "@mistralai/mistralai";
+import {
+  configureTelemetry,
+  shutdownTelemetry,
+} from "@mistralai/mistralai/extra/observability";
+
+const apiKey = process.env["MISTRAL_API_KEY"];
+if (!apiKey) {
+  throw new Error("missing MISTRAL_API_KEY environment variable");
+}
+
+const client = new Mistral({ apiKey });
+
+// Dedicated mode is the default; redaction is on by default.
+await configureTelemetry(client);
+
+const response = await client.chat.complete({
+  model: "mistral-small-latest",
+  messages: [{ role: "user", content: "What is the best French cheese?" }],
+});
+
+console.log(response.choices?.[0]?.message?.content);
+
+// Dedicated mode buffers spans in a BatchSpanProcessor. Flush and shut it down
+// so the span is exported before this short-lived script exits.
+await shutdownTelemetry(client);

--- a/examples/src/observability/global_provider_with_redaction.ts
+++ b/examples/src/observability/global_provider_with_redaction.ts
@@ -1,0 +1,49 @@
+/**
+ * Global provider mode with application-owned redaction.
+ *
+ * In global (or custom TracerProvider) mode your application owns the OTEL
+ * export pipeline, so `configureTelemetry`'s redaction argument is ignored (a
+ * warning is logged). To redact spans you wrap your own exporter with
+ * `RedactingSpanExporter`.
+ */
+
+import { trace } from "@opentelemetry/api";
+import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-http";
+import {
+    BasicTracerProvider,
+    BatchSpanProcessor,
+} from "@opentelemetry/sdk-trace-base";
+
+import { Mistral } from "@mistralai/mistralai";
+import {
+    configureTelemetry,
+    RedactingSpanExporter,
+} from "@mistralai/mistralai/extra/observability";
+
+const apiKey = process.env["MISTRAL_API_KEY"];
+if (!apiKey) {
+  throw new Error("missing MISTRAL_API_KEY environment variable");
+}
+
+// Build your own provider and wrap the exporter with redaction.
+const provider = new BasicTracerProvider({
+  spanProcessors: [
+    new BatchSpanProcessor(new RedactingSpanExporter(new OTLPTraceExporter())),
+  ],
+});
+trace.setGlobalTracerProvider(provider);
+
+const client = new Mistral({ apiKey });
+
+// SDK spans flow through the global provider configured above (already redacted
+// by the RedactingSpanExporter). Passing `redaction: false` tells the SDK we are
+// handling redaction ourselves, which suppresses the "redaction ignored in
+// global mode" warning.
+await configureTelemetry(client, "global", { redaction: false });
+
+const response = await client.chat.complete({
+  model: "mistral-small-latest",
+  messages: [{ role: "user", content: "Say hello." }],
+});
+
+console.log(response.choices?.[0]?.message?.content);

--- a/examples/src/observability/redaction_policies.ts
+++ b/examples/src/observability/redaction_policies.ts
@@ -1,0 +1,146 @@
+/**
+ * Choosing and extending a redaction policy in dedicated telemetry mode.
+ *
+ * The `redaction` option of `configureTelemetry` accepts:
+ *   - true (default): the regex (content-oriented) policy
+ *   - false: redaction disabled
+ *   - a RedactionPolicy instance (e.g. AttributeRedactionPolicy)
+ *   - a (key, value) => value | undefined callback
+ *
+ * Built-in policies expose their defaults as public constants so you can extend
+ * them instead of replacing them wholesale:
+ *   - AttributeRedactionPolicy: DEFAULT_SENSITIVE_ATTRIBUTE_KEYS,
+ *     DEFAULT_SENSITIVE_ATTRIBUTE_FRAGMENTS, DEFAULT_SAFE_ATTRIBUTE_KEYS,
+ *     DEFAULT_TOKEN_PATTERNS
+ *   - RegexRedactionPolicy: DEFAULT_PII_SECRET_PATTERNS
+ *
+ * CallbackRedactionPolicy is different in kind: instead of extending constants
+ * you supply a `(key, value) => value | undefined` function and decide per
+ * attribute. It is the only policy that can return `undefined` to drop an
+ * attribute entirely; the built-in policies replace values in place and never
+ * remove keys.
+ *
+ * `demonstrate()` applies the policies directly to a sample attribute mapping
+ * and prints the before/after; it needs no API key and no network. The live
+ * section wires an extended policy into `configureTelemetry` and issues a
+ * request (requires the optional OpenTelemetry SDK/exporter dependencies).
+ */
+
+import type { AttributeValue, Attributes } from "@opentelemetry/api";
+
+import { Mistral } from "@mistralai/mistralai";
+import {
+  AttributeRedactionPolicy,
+  CallbackRedactionPolicy,
+  configureTelemetry,
+  DEFAULT_PII_SECRET_PATTERNS,
+  DEFAULT_SENSITIVE_ATTRIBUTE_KEYS,
+  RegexRedactionPolicy,
+  shutdownTelemetry,
+  type AttributeMaskCallback,
+} from "@mistralai/mistralai/extra/observability";
+
+// A custom attribute key your application sets and wants masked, on top of the
+// built-in sensitive keys.
+const CUSTOMER_EMAIL_KEY = "app.customer.email";
+
+// A custom secret shape (e.g. an internal token) the default patterns don't know.
+const ACME_TOKEN_PATTERN = /\bacme-[a-z0-9]{16}\b/g;
+
+/** Key-oriented policy: defaults plus one extra sensitive key. */
+function buildAttributePolicy(): AttributeRedactionPolicy {
+  return new AttributeRedactionPolicy({
+    sensitiveKeys: new Set([...DEFAULT_SENSITIVE_ATTRIBUTE_KEYS, CUSTOMER_EMAIL_KEY]),
+  });
+}
+
+/** Content-oriented policy: default patterns plus one extra secret shape. */
+function buildRegexPolicy(): RegexRedactionPolicy {
+  return new RegexRedactionPolicy([...DEFAULT_PII_SECRET_PATTERNS, ACME_TOKEN_PATTERN]);
+}
+
+/**
+ * Callback: full control over each attribute. Return the value to keep it, a
+ * transformed value to mask it, or `undefined` to drop the attribute entirely
+ * (something the built-in policies cannot do).
+ */
+const customMask: AttributeMaskCallback = (key, value) => {
+  // Drop your application's private namespace outright.
+  if (key.startsWith("app.")) {
+    return undefined;
+  }
+  // Leave model/usage metadata untouched.
+  if (key.startsWith("gen_ai.request") || key.startsWith("gen_ai.usage")) {
+    return value;
+  }
+  // Mask anything else with your own marker.
+  return "***";
+};
+
+/** Callback-based policy wrapping the customMask function above. */
+function buildCallbackPolicy(): CallbackRedactionPolicy {
+  return new CallbackRedactionPolicy(customMask);
+}
+
+/** Show, without any network call, what each extended policy redacts. */
+function demonstrate(): void {
+  const attributes: Attributes = {
+    // Safe key, survives both policies.
+    "gen_ai.request.model": "mistral-small-latest",
+    // Built-in sensitive key: whole value dropped by the attribute policy.
+    "gen_ai.input.messages": "user: my card is 4111 1111 1111 1111",
+    // Custom key we added to the attribute policy's sensitive set.
+    [CUSTOMER_EMAIL_KEY]: "jane@example.com",
+    // Free-form value carrying secrets: caught by the regex policy's patterns.
+    "http.request.body":
+      "Authorization: Bearer sk-abcdefghijklmnopqrst; internal=acme-0123456789abcdef",
+  };
+
+  const cases: Array<[string, { redactAttributes: (a: Attributes) => Record<string, AttributeValue> }]> = [
+    ["AttributeRedactionPolicy (extended keys)", buildAttributePolicy()],
+    ["RegexRedactionPolicy (extended patterns)", buildRegexPolicy()],
+    ["CallbackRedactionPolicy (custom function)", buildCallbackPolicy()],
+  ];
+
+  for (const [label, policy] of cases) {
+    console.log(`\n${label}`);
+    const redacted = policy.redactAttributes(attributes);
+    for (const key of Object.keys(attributes)) {
+      // A callback may drop a key entirely (returns undefined), so it can be
+      // absent from the redacted mapping.
+      const after = key in redacted ? redacted[key] : "<dropped>";
+      console.log(`  ${key}`);
+      console.log(`    before: ${attributes[key]}`);
+      console.log(`    after : ${after}`);
+    }
+  }
+}
+
+demonstrate();
+
+const apiKey = process.env["MISTRAL_API_KEY"];
+if (!apiKey) {
+  console.log("\nSet MISTRAL_API_KEY to run the live configureTelemetry example.");
+} else {
+  const client = new Mistral({ apiKey });
+
+  // Wire the extended attribute policy into dedicated telemetry mode.
+  await configureTelemetry(client, "dedicated", { redaction: buildAttributePolicy() });
+
+  // Alternatives:
+  // await configureTelemetry(client, "dedicated", { redaction: buildRegexPolicy() });
+  // await configureTelemetry(client, "dedicated", { redaction: customMask });        // bare callback
+  // await configureTelemetry(client, "dedicated", { redaction: buildCallbackPolicy() });
+  // await configureTelemetry(client, "dedicated", { redaction: false });             // disable entirely
+
+  const response = await client.chat.complete({
+    model: "mistral-small-latest",
+    messages: [{ role: "user", content: "Say hello." }],
+  });
+
+  console.log(response.choices?.[0]?.message?.content);
+
+  // Flush and shut down the SDK-owned provider so the span is exported before
+  // this short-lived script exits.
+  await shutdownTelemetry(client);
+}

--- a/package.json
+++ b/package.json
@@ -7,6 +7,15 @@
   "peerDependenciesMeta": {
     "@opentelemetry/api": {
       "optional": true
+    },
+    "@opentelemetry/exporter-trace-otlp-http": {
+      "optional": true
+    },
+    "@opentelemetry/resources": {
+      "optional": true
+    },
+    "@opentelemetry/sdk-trace-base": {
+      "optional": true
     }
   },
   "type": "module",
@@ -75,7 +84,10 @@
     "prepublishOnly": "npm run build"
   },
   "peerDependencies": {
-    "@opentelemetry/api": "^1.9.0"
+    "@opentelemetry/api": "^1.9.0",
+    "@opentelemetry/exporter-trace-otlp-http": "^0.220.0",
+    "@opentelemetry/resources": "^2.9.0",
+    "@opentelemetry/sdk-trace-base": "^2.9.0"
   },
   "devDependencies": {
     "@opentelemetry/api": "^1.9.0",

--- a/src/extra/observability/index.ts
+++ b/src/extra/observability/index.ts
@@ -11,12 +11,36 @@ export {
   MISTRAL_TELEMETRY_ENDPOINT,
   MISTRAL_TELEMETRY_TRACES_PATH,
   setTracerProvider,
+  shutdownTelemetry,
   TELEMETRY_PROVIDER_DEDICATED,
   TELEMETRY_PROVIDER_GLOBAL,
   TelemetryConfigurationError,
+  type ConfigureTelemetryOptions,
   type TelemetryProvider,
   type TelemetryProviderMode,
   type TelemetrySetting,
 } from "./telemetry.js";
+export {
+  RedactingSpanExporter,
+  resolveRedaction,
+  type ExportResultLike,
+  type ReadableSpanLike,
+  type RedactionSetting,
+  type SpanExporterLike,
+} from "./redaction.js";
+export {
+  AttributeRedactionPolicy,
+  CallbackRedactionPolicy,
+  DEFAULT_PII_SECRET_PATTERNS,
+  DEFAULT_REDACTED_VALUE,
+  DEFAULT_SAFE_ATTRIBUTE_KEYS,
+  DEFAULT_SENSITIVE_ATTRIBUTE_FRAGMENTS,
+  DEFAULT_SENSITIVE_ATTRIBUTE_KEYS,
+  DEFAULT_TOKEN_PATTERNS,
+  defaultRedactionPolicy,
+  RedactionPolicy,
+  RegexRedactionPolicy,
+  type AttributeMaskCallback,
+} from "./redaction-policies.js";
 
 export type { Tracer, TracerOptions, TracerProvider } from "@opentelemetry/api";

--- a/src/extra/observability/redaction-policies.ts
+++ b/src/extra/observability/redaction-policies.ts
@@ -1,0 +1,469 @@
+/**
+ * Redaction policies for client-side redaction of telemetry spans.
+ *
+ * Can be customized through the CallbackRedactionPolicy, or extended by
+ * subclassing RedactionPolicy.
+ */
+
+import type { AttributeValue, Attributes } from "@opentelemetry/api";
+
+/**
+ * User-supplied per-attribute masker: given (key, value), return the value to
+ * keep. Return the value unchanged to keep it, a redacted value to mask it, or
+ * `undefined` to drop the attribute entirely.
+ */
+export type AttributeMaskCallback = (
+  key: string,
+  value: AttributeValue,
+) => AttributeValue | undefined;
+
+export const DEFAULT_REDACTED_VALUE = "[REDACTED]";
+
+export function defaultRedactionPolicy(): RedactionPolicy {
+  return new RegexRedactionPolicy();
+}
+
+/** Base class for redaction policies. */
+export abstract class RedactionPolicy {
+  /** Return a new attribute mapping with sensitive data removed. */
+  abstract redactAttributes(
+    attributes: Attributes | undefined,
+  ): Record<string, AttributeValue>;
+
+  /** Return the span name to export. Defaults to unchanged. */
+  redactSpanName(name: string): string {
+    return name;
+  }
+
+  /** Return the status description to export. Defaults to unchanged. */
+  redactStatusDescription(
+    description: string | undefined,
+  ): string | undefined {
+    return description;
+  }
+}
+
+export const DEFAULT_SENSITIVE_ATTRIBUTE_KEYS: ReadonlySet<string> = new Set([
+  "client.address",
+  "db.query.text",
+  "db.statement",
+  "exception.message",
+  "exception.stacktrace",
+  "gen_ai.input.messages",
+  "gen_ai.output.messages",
+  "gen_ai.tool.definitions",
+  "gen_ai.tool.call.arguments",
+  "gen_ai.tool.call.result",
+  "http.request.body",
+  "http.request.header.authorization",
+  "http.request.header.cookie",
+  "http.response.body",
+  "http.response.header.set-cookie",
+  "http.target",
+  "http.url",
+  "server.address",
+  "url.full",
+  "url.path",
+  "url.query",
+]);
+
+export const DEFAULT_SENSITIVE_ATTRIBUTE_FRAGMENTS: ReadonlySet<string> =
+  new Set([
+    "api_key",
+    "argument",
+    "arguments",
+    "authorization",
+    "body",
+    "completion",
+    "content",
+    "cookie",
+    "input",
+    "message",
+    "messages",
+    "output",
+    "password",
+    "payload",
+    "prompt",
+    "secret",
+    "set_cookie",
+    "token",
+  ]);
+
+export const DEFAULT_SAFE_ATTRIBUTE_KEYS: ReadonlySet<string> = new Set([
+  "agent.trace.public",
+  "client.port",
+  "error.type",
+  "exception.type",
+  "gen_ai.agent.name",
+  "gen_ai.conversation.id",
+  "gen_ai.operation.name",
+  "gen_ai.provider.name",
+  "gen_ai.request.model",
+  "gen_ai.response.finish_reasons",
+  "gen_ai.response.id",
+  "gen_ai.response.model",
+  "gen_ai.tool.call.id",
+  "gen_ai.tool.name",
+  "gen_ai.tool.type",
+  "http.request.method",
+  "http.response.status_code",
+  "network.protocol.name",
+  "network.protocol.version",
+  "server.port",
+  "url.scheme",
+]);
+
+export const DEFAULT_TOKEN_PATTERNS: readonly RegExp[] = [
+  /bearer\s+[a-z0-9._-]+/gi,
+  /\bgh[pousr]_[A-Za-z0-9_]{20,}\b/g,
+  /\bxox[baprs]-[A-Za-z0-9-]{10,}\b/g,
+  /\bsk-[A-Za-z0-9]{20,}\b/g,
+  /\bAKIA[0-9A-Z]{16}\b/g,
+  /\bAIza[0-9A-Za-z_-]{35}\b/g,
+  /\beyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\b/g,
+  /-----BEGIN [A-Z ]*PRIVATE KEY-----/g,
+  /\b[sr]k_(?:live|test)_[0-9A-Za-z]{10,}\b/g,
+  // AI providers
+  /\bsk-ant-[A-Za-z0-9\-_]{20,}\b/g,
+  /\bsk-proj-[A-Za-z0-9\-_]{20,}\b/g,
+  /\bhf_[A-Za-z0-9]{30,}\b/g,
+  // Dev / infra tokens
+  /\bgithub_pat_[A-Za-z0-9_]{22,}\b/g,
+  /\bglpat-[A-Za-z0-9\-=_]{20,22}\b/g,
+  /\bshp(?:at|ca|pa|ss)_[a-fA-F0-9]{32}\b/g,
+  /\bsq0(?:atp|csp|idp)-[0-9A-Za-z\-_]{22,43}\b/g,
+  /\bPMAK-[a-zA-Z0-9]{24,59}\b/g,
+  /\bphc_[a-zA-Z0-9_]{43}\b/g,
+  /\brubygems_[a-f0-9]{48}\b/g,
+  /\blin_api_[0-9A-Za-z]{40}\b/g,
+  /pypi-AgEIcHlwaS5vcmc[A-Za-z0-9\-_]{50,}/g,
+  /\bsecret_[A-Za-z0-9]{43}\b/g,
+  /[A-Za-z0-9]{14}\.atlasv1\.[A-Za-z0-9]{60,}/g,
+  /\bSG\.[A-Za-z0-9_-]{22}\.[A-Za-z0-9_-]{43}\b/g,
+  /\bpk_(?:live|test)_[0-9a-zA-Z]{24}\b/g,
+  // Webhook URLs (the whole URL is the secret)
+  /https:\/\/hooks\.slack\.com\/services\/[A-Za-z0-9/+]{40,}/g,
+  /https:\/\/discord(?:app)?\.com\/api\/webhooks\/[0-9]{17,}\/[A-Za-z0-9\-_]{60,}/g,
+  /https:\/\/hooks\.zapier\.com\/hooks\/catch\/[A-Za-z0-9/]{16,}/g,
+];
+
+export const DEFAULT_PII_SECRET_PATTERNS: readonly RegExp[] = [
+  ...DEFAULT_TOKEN_PATTERNS,
+  // Email addresses
+  /\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\b/g,
+  // Credit-card-like sequences (13-16 digits, optional spaces/dashes)
+  /\b(?:\d[ -]?){13,16}\b/g,
+  // IPv4 addresses
+  /\b(?:(?:25[0-5]|2[0-4]\d|1?\d?\d)\.){3}(?:25[0-5]|2[0-4]\d|1?\d?\d)\b/g,
+];
+
+const SAFE_KEY_PREFIXES: readonly string[] = ["gen_ai.usage."];
+
+function isPrimitive(value: AttributeValue): boolean {
+  return (
+    typeof value === "string" ||
+    typeof value === "boolean" ||
+    typeof value === "number"
+  );
+}
+
+/**
+ * Content-oriented policy based on regexes.
+ *
+ * This is the default policy. Leaves keys and structure intact, scans string
+ * values and redacts matched substrings. Fewer false positives than
+ * AttributeRedactionPolicy and aims to preserve observability value; may miss
+ * free-form PII or secrets not in the default patterns.
+ */
+export class RegexRedactionPolicy extends RedactionPolicy {
+  private readonly patterns: readonly RegExp[];
+  private readonly redactedValue: string;
+
+  constructor(
+    patterns: readonly RegExp[] = DEFAULT_PII_SECRET_PATTERNS,
+    options: { redactedValue?: string } = {},
+  ) {
+    super();
+    this.patterns = patterns;
+    this.redactedValue = options.redactedValue ?? DEFAULT_REDACTED_VALUE;
+  }
+
+  redactAttributes(
+    attributes: Attributes | undefined,
+  ): Record<string, AttributeValue> {
+    const redacted: Record<string, AttributeValue> = {};
+    if (attributes == null) {
+      return redacted;
+    }
+    for (const [key, value] of Object.entries(attributes)) {
+      if (value === undefined) {
+        continue;
+      }
+      redacted[key] = redactValue(value, this.patterns, this.redactedValue);
+    }
+    return redacted;
+  }
+
+  override redactSpanName(name: string): string {
+    return redactText(name, this.patterns, this.redactedValue);
+  }
+
+  override redactStatusDescription(
+    description: string | undefined,
+  ): string | undefined {
+    if (description == null) {
+      return description;
+    }
+    return redactText(description, this.patterns, this.redactedValue);
+  }
+}
+
+/**
+ * Key-oriented hybrid policy.
+ *
+ * An opt-in, high-recall alternative to the default policy: "safe by default",
+ * at the cost of erasing most prompt/response content. It redacts whole values
+ * for keys judged sensitive (explicit set, fragment match, or non-primitive
+ * value), then runs token patterns over the values it keeps to redact values.
+ *
+ * When `emitRedactionMetadata` is enabled, each redaction emits a companion
+ * attribute. For a value removed wholesale: `{key}.redacted_length` for strings,
+ * `{key}.redacted_count` for collections, `{key}.redacted_type` otherwise. For
+ * matches scrubbed from a value that is otherwise kept: `{key}.redacted_matches`,
+ * the number of substitutions made (summed across sequence elements).
+ */
+export class AttributeRedactionPolicy extends RedactionPolicy {
+  private readonly sensitiveKeys: ReadonlySet<string>;
+  private readonly safeKeys: ReadonlySet<string>;
+  private readonly sensitiveFragments: ReadonlySet<string>;
+  private readonly tokenPatterns: readonly RegExp[];
+  private readonly redactNonPrimitive: boolean;
+  private readonly redactedValue: string;
+  private readonly emitRedactionMetadata: boolean;
+
+  constructor(
+    options: {
+      sensitiveKeys?: ReadonlySet<string>;
+      safeKeys?: ReadonlySet<string>;
+      sensitiveFragments?: ReadonlySet<string>;
+      tokenPatterns?: readonly RegExp[];
+      redactNonPrimitive?: boolean;
+      redactedValue?: string;
+      emitRedactionMetadata?: boolean;
+    } = {},
+  ) {
+    super();
+    this.sensitiveKeys = options.sensitiveKeys ?? DEFAULT_SENSITIVE_ATTRIBUTE_KEYS;
+    this.safeKeys = options.safeKeys ?? DEFAULT_SAFE_ATTRIBUTE_KEYS;
+    this.sensitiveFragments =
+      options.sensitiveFragments ?? DEFAULT_SENSITIVE_ATTRIBUTE_FRAGMENTS;
+    this.tokenPatterns = options.tokenPatterns ?? DEFAULT_TOKEN_PATTERNS;
+    this.redactNonPrimitive = options.redactNonPrimitive ?? true;
+    this.redactedValue = options.redactedValue ?? DEFAULT_REDACTED_VALUE;
+    this.emitRedactionMetadata = options.emitRedactionMetadata ?? false;
+  }
+
+  private shouldRedact(key: string, value: AttributeValue): boolean {
+    const normalizedKey = key.toLowerCase();
+    if (this.safeKeys.has(normalizedKey)) {
+      return false;
+    }
+    if (SAFE_KEY_PREFIXES.some((prefix) => normalizedKey.startsWith(prefix))) {
+      return false;
+    }
+    if (this.sensitiveKeys.has(normalizedKey)) {
+      return true;
+    }
+    if (this.hasSensitiveFragment(normalizedKey)) {
+      return true;
+    }
+    return this.redactNonPrimitive && !isPrimitive(value);
+  }
+
+  private hasSensitiveFragment(normalizedKey: string): boolean {
+    const normalizedWords = normalizedKey.replace(/-/g, "_").replace(/\./g, "_");
+    const keyFragments = new Set(
+      normalizedWords.split("_").filter((word) => word.length > 0),
+    );
+    for (const fragment of this.sensitiveFragments) {
+      if (keyFragments.has(fragment) || normalizedWords.includes(fragment)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  redactAttributes(
+    attributes: Attributes | undefined,
+  ): Record<string, AttributeValue> {
+    const redacted: Record<string, AttributeValue> = {};
+    if (attributes == null) {
+      return redacted;
+    }
+
+    for (const [key, value] of Object.entries(attributes)) {
+      if (value === undefined) {
+        continue;
+      }
+      if (this.emitRedactionMetadata && isRedactionMetadata(key)) {
+        redacted[key] = value;
+        continue;
+      }
+      if (this.shouldRedact(key, value)) {
+        redacted[key] = this.redactedValue;
+        if (this.emitRedactionMetadata) {
+          Object.assign(redacted, redactionMetadata(key, value));
+        }
+        continue;
+      }
+      if (this.emitRedactionMetadata) {
+        const [keptValue, matches] = redactValueCounting(
+          value,
+          this.tokenPatterns,
+          this.redactedValue,
+        );
+        redacted[key] = keptValue;
+        if (matches) {
+          redacted[`${key}.redacted_matches`] = matches;
+        }
+        continue;
+      }
+      redacted[key] = redactValue(value, this.tokenPatterns, this.redactedValue);
+    }
+
+    return redacted;
+  }
+
+  override redactStatusDescription(
+    description: string | undefined,
+  ): string | undefined {
+    if (description == null) {
+      return description;
+    }
+    return this.redactedValue;
+  }
+}
+
+/**
+ * Callback-based policy for users to provide custom redaction capabilities.
+ *
+ * The callback is invoked per attribute and should return the value to keep or
+ * `undefined` to drop the attribute. Span name and status description are left
+ * unchanged (the callback operates on attributes only).
+ */
+export class CallbackRedactionPolicy extends RedactionPolicy {
+  private readonly maskFunction: AttributeMaskCallback;
+
+  constructor(maskFunction: AttributeMaskCallback) {
+    super();
+    this.maskFunction = maskFunction;
+  }
+
+  redactAttributes(
+    attributes: Attributes | undefined,
+  ): Record<string, AttributeValue> {
+    const redacted: Record<string, AttributeValue> = {};
+    if (attributes == null) {
+      return redacted;
+    }
+
+    for (const [key, value] of Object.entries(attributes)) {
+      if (value === undefined) {
+        continue;
+      }
+      const masked = this.maskFunction(key, value);
+      if (masked === undefined) {
+        continue;
+      }
+      redacted[key] = masked;
+    }
+
+    return redacted;
+  }
+}
+
+function redactValue(
+  value: AttributeValue,
+  patterns: readonly RegExp[],
+  redactedValue: string = DEFAULT_REDACTED_VALUE,
+): AttributeValue {
+  return redactValueCounting(value, patterns, redactedValue)[0];
+}
+
+function redactValueCounting(
+  value: AttributeValue,
+  patterns: readonly RegExp[],
+  redactedValue: string = DEFAULT_REDACTED_VALUE,
+): [AttributeValue, number] {
+  if (typeof value === "string") {
+    return redactTextCounting(value, patterns, redactedValue);
+  }
+  if (Array.isArray(value)) {
+    let total = 0;
+    const items = value.map((item) => {
+      if (typeof item === "string") {
+        const [redactedItem, count] = redactTextCounting(
+          item,
+          patterns,
+          redactedValue,
+        );
+        total += count;
+        return redactedItem;
+      }
+      return item;
+    });
+    return [items as AttributeValue, total];
+  }
+  return [value, 0];
+}
+
+function redactText(
+  text: string,
+  patterns: readonly RegExp[],
+  redactedValue: string = DEFAULT_REDACTED_VALUE,
+): string {
+  return redactTextCounting(text, patterns, redactedValue)[0];
+}
+
+function redactTextCounting(
+  text: string,
+  patterns: readonly RegExp[],
+  redactedValue: string = DEFAULT_REDACTED_VALUE,
+): [string, number] {
+  let redacted = text;
+  let total = 0;
+  for (const pattern of patterns) {
+    redacted = redacted.replace(pattern, () => {
+      total += 1;
+      return redactedValue;
+    });
+  }
+  return [redacted, total];
+}
+
+const REDACTION_METADATA_SUFFIXES: readonly string[] = [
+  ".redacted_count",
+  ".redacted_length",
+  ".redacted_matches",
+  ".redacted_type",
+];
+
+function isRedactionMetadata(key: string): boolean {
+  const normalized = key.toLowerCase();
+  return REDACTION_METADATA_SUFFIXES.some((suffix) =>
+    normalized.endsWith(suffix),
+  );
+}
+
+function redactionMetadata(
+  key: string,
+  value: AttributeValue,
+): Record<string, AttributeValue> {
+  if (typeof value === "string") {
+    return { [`${key}.redacted_length`]: value.length };
+  }
+  if (Array.isArray(value)) {
+    return { [`${key}.redacted_count`]: value.length };
+  }
+  return { [`${key}.redacted_type`]: typeof value };
+}

--- a/src/extra/observability/redaction.ts
+++ b/src/extra/observability/redaction.ts
@@ -1,0 +1,256 @@
+/**
+ * Client-side redaction of telemetry spans before they are exported.
+ *
+ * This module provides a configurable, export-time masking layer for
+ * OpenTelemetry spans so PII/secrets never leave the client. It is the primary,
+ * reusable primitive: any OTEL application can wrap the exporter it owns with
+ * `RedactingSpanExporter`, and the Mistral SDK installs it automatically in
+ * dedicated telemetry mode (see `configureTelemetry`). Several redaction
+ * policies are implemented in `redaction-policies.ts`.
+ *
+ * The module stays importable without the optional OpenTelemetry SDK: it only
+ * manipulates plain objects and delegates the actual export to the wrapped
+ * exporter. Structural types are used instead of importing
+ * `@opentelemetry/sdk-trace-base` so no extra dependency is required to import.
+ */
+
+import type { Attributes } from "@opentelemetry/api";
+
+import {
+    CallbackRedactionPolicy,
+    defaultRedactionPolicy,
+    RedactionPolicy,
+    type AttributeMaskCallback,
+} from "./redaction-policies.js";
+
+/**
+ * Redaction setting accepted by `configureTelemetry` and the exporter:
+ * - `true`: the default (regex) policy
+ * - `false`: redaction disabled
+ * - a `RedactionPolicy` instance
+ * - a `(key, value) => value | undefined` callback
+ */
+export type RedactionSetting = boolean | RedactionPolicy | AttributeMaskCallback;
+
+type SpanStatusLike = { code: number; message?: string };
+
+type TimedEventLike = {
+  name: string;
+  attributes?: Attributes;
+};
+
+type LinkLike = {
+  attributes?: Attributes;
+};
+
+type ResourceLike = {
+  attributes: Attributes;
+};
+
+/**
+ * Minimal structural view of an OpenTelemetry `ReadableSpan`. Only the redacted
+ * surface is described; every other field is preserved via the prototype chain.
+ */
+export interface ReadableSpanLike {
+  name: string;
+  attributes: Attributes;
+  events: TimedEventLike[];
+  links: LinkLike[];
+  resource: ResourceLike;
+  status: SpanStatusLike;
+  spanContext(): unknown;
+}
+
+export type ExportResultLike = { code: number; error?: Error };
+
+/** Minimal structural view of an OpenTelemetry `SpanExporter`. */
+export interface SpanExporterLike {
+  export(
+    spans: ReadableSpanLike[],
+    resultCallback: (result: ExportResultLike) => void,
+  ): void;
+  shutdown(): Promise<void>;
+  forceFlush?(): Promise<void>;
+}
+
+/**
+ * Resolve a redaction setting into a policy, or `undefined` to disable
+ * redaction. `true` yields the default policy, `false` disables redaction
+ * entirely, and a policy or `(key, value) => value | undefined` callback is used
+ * as-is.
+ */
+export function resolveRedaction(
+  redaction: RedactionSetting,
+): RedactionPolicy | undefined {
+  if (redaction === false) {
+    return undefined;
+  }
+  if (redaction === true) {
+    return defaultRedactionPolicy();
+  }
+  return resolvePolicy(redaction);
+}
+
+function resolvePolicy(
+  policy: RedactionPolicy | AttributeMaskCallback | undefined,
+): RedactionPolicy {
+  if (policy == null) {
+    return defaultRedactionPolicy();
+  }
+  if (policy instanceof RedactionPolicy) {
+    return policy;
+  }
+  if (typeof policy === "function") {
+    return new CallbackRedactionPolicy(policy);
+  }
+  throw new TypeError(
+    "redaction policy must be a RedactionPolicy, a callable, or undefined; " +
+      `got ${typeof policy}.`,
+  );
+}
+
+/**
+ * Wrap any `SpanExporter` to redact spans before delegating export.
+ *
+ * @example
+ * ```ts
+ * const exporter = new RedactingSpanExporter(new OTLPTraceExporter());
+ * provider.addSpanProcessor(new BatchSpanProcessor(exporter));
+ * ```
+ */
+export class RedactingSpanExporter implements SpanExporterLike {
+  private readonly exporter: SpanExporterLike;
+  private readonly policy: RedactionPolicy;
+
+  constructor(
+    exporter: SpanExporterLike,
+    policy?: RedactionPolicy | AttributeMaskCallback,
+  ) {
+    this.exporter = exporter;
+    this.policy = resolvePolicy(policy);
+  }
+
+  export(
+    spans: ReadableSpanLike[],
+    resultCallback: (result: ExportResultLike) => void,
+  ): void {
+    const redacted = spans.map((span) => redactSpan(span, this.policy));
+    this.exporter.export(redacted, resultCallback);
+  }
+
+  shutdown(): Promise<void> {
+    return this.exporter.shutdown();
+  }
+
+  forceFlush(): Promise<void> {
+    return this.exporter.forceFlush?.() ?? Promise.resolve();
+  }
+}
+
+/**
+ * Define an own data property on `target`, shadowing the prototype. Plain
+ * assignment (`target.key = value`) fails when the prototype exposes `key` as a
+ * getter-only accessor (e.g. OpenTelemetry's `Resource.attributes`), so we
+ * always define the override explicitly.
+ */
+function overrideProperty<T extends object>(
+  target: T,
+  key: keyof T,
+  value: T[keyof T],
+): void {
+  Object.defineProperty(target, key, {
+    value,
+    enumerable: true,
+    configurable: true,
+    writable: true,
+  });
+}
+
+/**
+ * Shallow-clone an object, keeping its prototype and copying every own field as
+ * an own property.
+ */
+function shallowClone<T extends object>(source: T): T {
+  return Object.create(
+    Object.getPrototypeOf(source) as object | null,
+    Object.getOwnPropertyDescriptors(source),
+  ) as T;
+}
+
+/**
+ * Return a redacted clone of a span: same prototype, every own field copied, so
+ * untouched fields survive exporters that spread or enumerate it ({...span},
+ * Object.keys). Only the sensitive surface is overridden.
+ */
+export function redactSpan(
+  span: ReadableSpanLike,
+  policy: RedactionPolicy,
+): ReadableSpanLike {
+  const redacted = shallowClone(span);
+  overrideProperty(redacted, "name", policy.redactSpanName(span.name));
+  overrideProperty(redacted, "attributes", policy.redactAttributes(span.attributes));
+  overrideProperty(redacted, "events", redactEvents(span.events, policy));
+  overrideProperty(redacted, "links", redactLinks(span.links, policy));
+  overrideProperty(redacted, "resource", redactResource(span.resource, policy));
+  overrideProperty(redacted, "status", redactStatus(span.status, policy));
+  return redacted;
+}
+
+function redactEvents(
+  events: TimedEventLike[] | undefined,
+  policy: RedactionPolicy,
+): TimedEventLike[] {
+  if (events == null) {
+    return [];
+  }
+  return events.map((event) => {
+    const redacted = shallowClone(event);
+    overrideProperty(redacted, "attributes", policy.redactAttributes(event.attributes));
+    return redacted;
+  });
+}
+
+function redactLinks(
+  links: LinkLike[] | undefined,
+  policy: RedactionPolicy,
+): LinkLike[] {
+  if (links == null) {
+    return [];
+  }
+  return links.map((link) => {
+    const redacted = shallowClone(link);
+    overrideProperty(redacted, "attributes", policy.redactAttributes(link.attributes));
+    return redacted;
+  });
+}
+
+function redactResource(
+  resource: ResourceLike | undefined,
+  policy: RedactionPolicy,
+): ResourceLike {
+  if (resource == null) {
+    return resource as unknown as ResourceLike;
+  }
+  const redacted = shallowClone(resource);
+  overrideProperty(
+    redacted,
+    "attributes",
+    policy.redactAttributes(resource.attributes) as Attributes,
+  );
+  return redacted;
+}
+
+function redactStatus(
+  status: SpanStatusLike | undefined,
+  policy: RedactionPolicy,
+): SpanStatusLike {
+  if (status == null) {
+    return status as unknown as SpanStatusLike;
+  }
+  const message = policy.redactStatusDescription(status.message);
+  const redacted: SpanStatusLike = { code: status.code };
+  if (message !== undefined) {
+    redacted.message = message;
+  }
+  return redacted;
+}

--- a/src/extra/observability/telemetry.ts
+++ b/src/extra/observability/telemetry.ts
@@ -9,6 +9,12 @@ import type { SDKOptions } from "../../lib/config.js";
 import type { SecurityState } from "../../lib/security.js";
 import { OTEL_SERVICE_NAME } from "./otel.js";
 import { getRegisteredTracerProvider } from "./provider.js";
+import {
+  RedactingSpanExporter,
+  resolveRedaction,
+  type RedactionSetting,
+  type SpanExporterLike,
+} from "./redaction.js";
 
 export const MISTRAL_SDK_TELEMETRY_ENV = "MISTRAL_SDK_TELEMETRY";
 export const MISTRAL_TELEMETRY_BASE_URL = "https://api.mistral.ai";
@@ -60,6 +66,7 @@ export type CreateTelemetryTracerProviderOptions = {
   apiKey: string | null | undefined;
   baseURL?: string | URL | null | undefined;
   moduleLoader?: ModuleLoader | undefined;
+  redaction?: RedactionSetting | undefined;
 };
 
 type CreateTelemetryTracerProvider = (
@@ -70,6 +77,11 @@ type ConfigureTelemetryForHookOptions = {
   telemetry?: TelemetrySetting;
   replaceExisting?: boolean | undefined;
   createTelemetryTracerProvider?: CreateTelemetryTracerProvider;
+  redaction?: RedactionSetting | undefined;
+};
+
+export type ConfigureTelemetryOptions = {
+  redaction?: RedactionSetting | undefined;
 };
 
 type OtelResource = { merge?: (resource: unknown) => unknown };
@@ -87,25 +99,51 @@ export class TelemetryConfigurationError extends Error {
 export async function configureTelemetry(
   client: ClientWithHooks,
   provider: TelemetryProvider = TELEMETRY_PROVIDER_DEDICATED,
+  options: ConfigureTelemetryOptions = {},
 ): Promise<boolean> {
   const hook = getTracingHook(client);
+  const redaction = options.redaction;
 
   if (typeof provider === "string") {
     const providerMode = resolveProviderMode(provider);
     if (providerMode === TELEMETRY_PROVIDER_GLOBAL) {
+      warnRedactionIgnored(redaction, TELEMETRY_PROVIDER_GLOBAL);
       return useGlobalTracerProvider(hook, { replaceExisting: true });
     }
 
     return configureTelemetryForHook(
       hook,
       { baseURL: client._baseURL, options: client._options },
-      { telemetry: providerMode, replaceExisting: true },
+      { telemetry: providerMode, replaceExisting: true, redaction },
     );
   }
 
+  warnRedactionIgnored(redaction, "custom");
   markTelemetryConfigurationChanged(hook);
   await attachCustomTracerProvider(hook, provider);
   return true;
+}
+
+/**
+ * Redaction is applied only in dedicated provider mode, where the SDK owns the
+ * exporter. In global/custom modes the application owns the export pipeline, so
+ * the argument is ignored. Because redaction is on by default, warn (unless it
+ * was explicitly disabled) so callers know their spans are not redacted here and
+ * that they must wrap their own exporter with `RedactingSpanExporter`.
+ */
+function warnRedactionIgnored(
+  redaction: RedactionSetting | undefined,
+  mode: string,
+): void {
+  if (redaction === false) {
+    return;
+  }
+  warnLog(
+    "Telemetry redaction is only applied in 'dedicated' provider mode, where " +
+      `the Mistral SDK owns the exporter. In '${mode}' mode the application ` +
+      "owns the export pipeline; wrap your exporter with RedactingSpanExporter " +
+      "to redact spans. Ignoring the redaction argument.",
+  );
 }
 
 export async function setTracerProvider(
@@ -113,6 +151,21 @@ export async function setTracerProvider(
   provider: TracerProvider,
 ): Promise<boolean> {
   return configureTelemetry(client, provider);
+}
+
+/**
+ * Flush and shut down the SDK-owned telemetry provider attached to `client`.
+ *
+ * In dedicated mode the SDK owns a BatchSpanProcessor that buffers spans and
+ * only exports them on a timer or on shutdown. Node has no reliable async exit
+ * hook to flush automatically (unlike Python's finalizer), so short-lived
+ * programs must call this before exiting or their buffered spans are dropped.
+ * In global/custom provider modes the application owns the export pipeline, so
+ * this is a no-op.
+ */
+export async function shutdownTelemetry(client: ClientWithHooks): Promise<void> {
+  const hook = getTracingHook(client);
+  await shutdownTelemetryProvider(hook);
 }
 
 export function getTelemetryTracer(
@@ -215,6 +268,7 @@ async function initializeTelemetryProvider(
   const provider = await createProvider({
     apiKey: await resolveApiKey(context),
     baseURL: context.baseURL ?? context.options?.serverURL,
+    redaction: options.redaction,
   });
 
   if (hook._telemetryConfigurationVersion !== configurationVersion) {
@@ -273,7 +327,11 @@ export async function _createTelemetryTracerProvider(
     url: resolveMistralTelemetryEndpoint(options.baseURL),
     headers: { Authorization: asBearerToken(options.apiKey) },
   });
-  const spanProcessor = new BatchSpanProcessor(exporter);
+  const policy = resolveRedaction(options.redaction ?? true);
+  const spanExporter = policy
+    ? new RedactingSpanExporter(exporter as SpanExporterLike, policy)
+    : exporter;
+  const spanProcessor = new BatchSpanProcessor(spanExporter);
   const resource = createResource(resourcesModule, {
     "service.name": OTEL_SERVICE_NAME,
   });
@@ -523,8 +581,23 @@ function readEnv(name: string): string | undefined {
   }
 }
 
+function warnLog(message: string): void {
+  try {
+    (globalThis as { console?: { warn?: (message: string) => void } })
+      .console?.warn?.(message);
+  } catch {
+    // Ignore logging failures.
+  }
+}
+
 async function loadModule(specifier: string): Promise<Record<string, unknown>> {
-  return await import(specifier) as Record<string, unknown>;
+  // Optional OpenTelemetry peer dependencies are loaded lazily at runtime. The
+  // specifier is dynamic, so bundlers cannot (and must not) statically resolve
+  // it — the magic comments keep it as a runtime import for webpack, Turbopack
+  // and Vite instead of failing the build with "Can't resolve <dynamic>".
+  return await import(
+    /* webpackIgnore: true */ /* turbopackIgnore: true */ /* @vite-ignore */ specifier
+  ) as Record<string, unknown>;
 }
 
 function requireExportConstructor(

--- a/tests/extra/observability/redaction-policies.test.ts
+++ b/tests/extra/observability/redaction-policies.test.ts
@@ -1,0 +1,282 @@
+import {
+  AttributeRedactionPolicy,
+  CallbackRedactionPolicy,
+  DEFAULT_REDACTED_VALUE,
+  RegexRedactionPolicy,
+} from "../../../src/extra/observability/redaction-policies.js";
+
+describe("AttributeRedactionPolicy", () => {
+  test("sensitive key redacted wholesale", () => {
+    const out = new AttributeRedactionPolicy().redactAttributes({
+      "gen_ai.input.messages": "hello",
+    });
+    expect(out["gen_ai.input.messages"]).toBe(DEFAULT_REDACTED_VALUE);
+  });
+
+  test("safe key kept", () => {
+    const out = new AttributeRedactionPolicy().redactAttributes({
+      "gen_ai.request.model": "mistral-large",
+    });
+    expect(out["gen_ai.request.model"]).toBe("mistral-large");
+  });
+
+  test("usage prefix kept", () => {
+    const out = new AttributeRedactionPolicy().redactAttributes({
+      "gen_ai.usage.input_tokens": 42,
+    });
+    expect(out["gen_ai.usage.input_tokens"]).toBe(42);
+  });
+
+  test("fragment match redacted", () => {
+    const out = new AttributeRedactionPolicy().redactAttributes({
+      "custom.prompt.text": "secret prompt",
+    });
+    expect(out["custom.prompt.text"]).toBe(DEFAULT_REDACTED_VALUE);
+  });
+
+  test("token pattern applied to kept string", () => {
+    const out = new AttributeRedactionPolicy().redactAttributes({
+      note: "call token ghp_abcdefghijklmnopqrstuvwxyz0123 now",
+    });
+    expect(out["note"]).toBe("call token [REDACTED] now");
+  });
+
+  test("non-primitive redacted", () => {
+    const out = new AttributeRedactionPolicy().redactAttributes({
+      data: ["a", "b"],
+    });
+    expect(out["data"]).toBe(DEFAULT_REDACTED_VALUE);
+  });
+
+  test("non-primitive kept when disabled", () => {
+    const policy = new AttributeRedactionPolicy({ redactNonPrimitive: false });
+    const out = policy.redactAttributes({ "safeish.list": ["a", "b"] });
+    expect(out["safeish.list"]).toEqual(["a", "b"]);
+  });
+
+  test("string sequence scanned element-wise when kept", () => {
+    const policy = new AttributeRedactionPolicy({ redactNonPrimitive: false });
+    const out = policy.redactAttributes({
+      tags: ["plain", "ghp_abcdefghijklmnopqrstuvwxyz0123"],
+    });
+    expect(out["tags"]).toEqual(["plain", DEFAULT_REDACTED_VALUE]);
+  });
+
+  test("safe key string sequence scanned", () => {
+    const out = new AttributeRedactionPolicy().redactAttributes({
+      "gen_ai.response.finish_reasons": ["stop", "Bearer abc.def"],
+    });
+    expect(out["gen_ai.response.finish_reasons"]).toEqual([
+      "stop",
+      DEFAULT_REDACTED_VALUE,
+    ]);
+  });
+
+  test("undefined attributes returns empty", () => {
+    expect(new AttributeRedactionPolicy().redactAttributes(undefined)).toEqual(
+      {},
+    );
+  });
+
+  test("status description redacted", () => {
+    const policy = new AttributeRedactionPolicy();
+    expect(policy.redactStatusDescription("boom: user@x.com")).toBe(
+      DEFAULT_REDACTED_VALUE,
+    );
+    expect(policy.redactStatusDescription(undefined)).toBeUndefined();
+  });
+
+  test("span name unchanged", () => {
+    expect(
+      new AttributeRedactionPolicy().redactSpanName("chat mistral-large"),
+    ).toBe("chat mistral-large");
+  });
+
+  test("custom redacted value", () => {
+    const policy = new AttributeRedactionPolicy({ redactedValue: "XXX" });
+    const out = policy.redactAttributes({ "http.url": "https://x" });
+    expect(out["http.url"]).toBe("XXX");
+  });
+});
+
+describe("AttributeRedactionPolicy redaction metadata", () => {
+  test("no metadata by default", () => {
+    const out = new AttributeRedactionPolicy().redactAttributes({
+      "gen_ai.input.messages": "hello",
+    });
+    expect(out).toEqual({ "gen_ai.input.messages": DEFAULT_REDACTED_VALUE });
+  });
+
+  test("string redaction emits length", () => {
+    const policy = new AttributeRedactionPolicy({ emitRedactionMetadata: true });
+    const out = policy.redactAttributes({ "gen_ai.input.messages": "hello" });
+    expect(out["gen_ai.input.messages"]).toBe(DEFAULT_REDACTED_VALUE);
+    expect(out["gen_ai.input.messages.redacted_length"]).toBe(5);
+  });
+
+  test("sequence redaction emits count", () => {
+    const policy = new AttributeRedactionPolicy({ emitRedactionMetadata: true });
+    const out = policy.redactAttributes({ data: ["a", "b", "c"] });
+    expect(out["data"]).toBe(DEFAULT_REDACTED_VALUE);
+    expect(out["data.redacted_count"]).toBe(3);
+  });
+
+  test("kept string emits match count", () => {
+    const policy = new AttributeRedactionPolicy({ emitRedactionMetadata: true });
+    const out = policy.redactAttributes({
+      note: "token ghp_abcdefghijklmnopqrstuvwxyz0123 now",
+    });
+    expect(out["note"]).toBe("token [REDACTED] now");
+    expect(out["note.redacted_matches"]).toBe(1);
+  });
+
+  test("kept sequence sums match count", () => {
+    const policy = new AttributeRedactionPolicy({
+      emitRedactionMetadata: true,
+      redactNonPrimitive: false,
+    });
+    const out = policy.redactAttributes({
+      tags: [
+        "plain",
+        "ghp_abcdefghijklmnopqrstuvwxyz0123",
+        "Bearer abc.def",
+      ],
+    });
+    expect(out["tags"]).toEqual([
+      "plain",
+      DEFAULT_REDACTED_VALUE,
+      DEFAULT_REDACTED_VALUE,
+    ]);
+    expect(out["tags.redacted_matches"]).toBe(2);
+  });
+
+  test("kept string without match has no metadata", () => {
+    const policy = new AttributeRedactionPolicy({ emitRedactionMetadata: true });
+    const out = policy.redactAttributes({ "gen_ai.request.model": "mistral-large" });
+    expect(out).toEqual({ "gen_ai.request.model": "mistral-large" });
+  });
+
+  test("idempotent on already redacted attributes", () => {
+    const policy = new AttributeRedactionPolicy({ emitRedactionMetadata: true });
+    const first = policy.redactAttributes({ "gen_ai.input.messages": "hello" });
+    const second = policy.redactAttributes(first);
+    expect(second).toEqual(first);
+  });
+
+  test("idempotent on kept match metadata", () => {
+    const policy = new AttributeRedactionPolicy({ emitRedactionMetadata: true });
+    const first = policy.redactAttributes({
+      note: "token ghp_abcdefghijklmnopqrstuvwxyz0123 now",
+    });
+    const second = policy.redactAttributes(first);
+    expect(second).toEqual(first);
+  });
+});
+
+describe("RegexRedactionPolicy", () => {
+  test("email redacted inline preserving structure", () => {
+    const out = new RegexRedactionPolicy().redactAttributes({
+      "gen_ai.input.messages": '{"content":"reach me at a@b.com"}',
+    });
+    expect(out["gen_ai.input.messages"]).toBe(
+      '{"content":"reach me at [REDACTED]"}',
+    );
+  });
+
+  test("token redacted", () => {
+    const out = new RegexRedactionPolicy().redactAttributes({
+      h: "Bearer abc.def-ghi",
+    });
+    expect(out["h"]).toBe("[REDACTED]");
+  });
+
+  test("non-matching string kept", () => {
+    const out = new RegexRedactionPolicy().redactAttributes({
+      "server.address": "prod-host-1",
+    });
+    expect(out["server.address"]).toBe("prod-host-1");
+  });
+
+  test("non-string untouched", () => {
+    const out = new RegexRedactionPolicy().redactAttributes({ n: 5, b: true });
+    expect(out).toEqual({ n: 5, b: true });
+  });
+
+  test("span name scanned", () => {
+    expect(new RegexRedactionPolicy().redactSpanName("op a@b.com")).toBe(
+      "op [REDACTED]",
+    );
+  });
+
+  test("status description scanned", () => {
+    expect(
+      new RegexRedactionPolicy().redactStatusDescription("failed for a@b.com"),
+    ).toBe("failed for [REDACTED]");
+  });
+
+  // Fixtures are assembled from fragments so the source never contains a
+  // contiguous secret-shaped literal (which trips push-protection scanners),
+  // while the runtime value still exercises the redaction patterns.
+  test.each([
+    "AKIA" + "A".repeat(16),
+    "AIza" + "a".repeat(35),
+    "eyJhbGciOiJIUzI1NiJ9" + "." + "eyJzdWIiOiIxMjM0" + "." + "abc123",
+    "-----BEGIN RSA PRIVATE KEY-----",
+    "sk_live_" + "a".repeat(16),
+    "sk-ant-" + "a".repeat(24),
+    "hf_" + "a".repeat(34),
+    "github_pat_" + "a".repeat(24),
+    "glpat-" + "a".repeat(20),
+    "shpat_" + "0".repeat(32),
+    "sq0atp-" + "a".repeat(24),
+    "PMAK-" + "a".repeat(24),
+    "phc_" + "a".repeat(43),
+    "SG." + "a".repeat(22) + "." + "a".repeat(43),
+    "pk_live_" + "a".repeat(24),
+    "https://hooks.slack.com/services/" + "A".repeat(44),
+  ])("secret pattern redacted: %s", (secret) => {
+    const out = new RegexRedactionPolicy().redactAttributes({
+      v: `leak ${secret} here`,
+    });
+    const value = out["v"];
+    expect(typeof value).toBe("string");
+    expect(value as string).not.toContain(secret);
+    expect(value as string).toContain(DEFAULT_REDACTED_VALUE);
+  });
+
+  test("string sequence scanned preserving container", () => {
+    const out = new RegexRedactionPolicy().redactAttributes({
+      msgs: ["hello", "reach me at a@b.com"],
+    });
+    expect(out["msgs"]).toEqual(["hello", "reach me at [REDACTED]"]);
+  });
+
+  test("numeric sequence untouched", () => {
+    const out = new RegexRedactionPolicy().redactAttributes({ nums: [1, 2, 3] });
+    expect(out["nums"]).toEqual([1, 2, 3]);
+  });
+});
+
+describe("CallbackRedactionPolicy", () => {
+  test("mask applied per attribute", () => {
+    const policy = new CallbackRedactionPolicy((key, value) =>
+      key.includes("message") ? "[X]" : value,
+    );
+    const out = policy.redactAttributes({
+      "gen_ai.output.messages": "hi",
+      "gen_ai.request.model": "m",
+    });
+    expect(out).toEqual({
+      "gen_ai.output.messages": "[X]",
+      "gen_ai.request.model": "m",
+    });
+  });
+
+  test("returning undefined drops attribute", () => {
+    const policy = new CallbackRedactionPolicy((key, value) =>
+      key === "drop" ? undefined : value,
+    );
+    const out = policy.redactAttributes({ drop: "x", keep: "y" });
+    expect(out).toEqual({ keep: "y" });
+  });
+});

--- a/tests/extra/observability/redaction.test.ts
+++ b/tests/extra/observability/redaction.test.ts
@@ -1,0 +1,263 @@
+import {
+  RedactingSpanExporter,
+  redactSpan,
+  resolveRedaction,
+  type ExportResultLike,
+  type ReadableSpanLike,
+  type SpanExporterLike,
+} from "../../../src/extra/observability/redaction.js";
+import {
+  AttributeRedactionPolicy,
+  CallbackRedactionPolicy,
+  DEFAULT_REDACTED_VALUE,
+  RegexRedactionPolicy,
+} from "../../../src/extra/observability/redaction-policies.js";
+import type { Attributes } from "@opentelemetry/api";
+
+type FakeSpan = ReadableSpanLike & {
+  startTime: number;
+  kind: number;
+};
+
+function makeSpan(
+  attributes: Attributes = {},
+  overrides: Partial<FakeSpan> = {},
+): FakeSpan {
+  const spanContext = { traceId: "trace-1", spanId: "span-1", traceFlags: 1 };
+  return {
+    name: "parent",
+    attributes,
+    events: [
+      { name: "exception", attributes: { "exception.message": "boom" } },
+    ],
+    links: [{ attributes: { "gen_ai.input.messages": "linked secret" } }],
+    resource: { attributes: { "service.name": "svc" } },
+    status: { code: 2, message: "boom detail" },
+    startTime: 123,
+    kind: 3,
+    spanContext: () => spanContext,
+    ...overrides,
+  };
+}
+
+class InMemorySpanExporter implements SpanExporterLike {
+  spans: ReadableSpanLike[] = [];
+  shutdownCalled = false;
+  flushCalled = false;
+
+  export(
+    spans: ReadableSpanLike[],
+    resultCallback: (result: ExportResultLike) => void,
+  ): void {
+    this.spans.push(...spans);
+    resultCallback({ code: 0 });
+  }
+
+  shutdown(): Promise<void> {
+    this.shutdownCalled = true;
+    return Promise.resolve();
+  }
+
+  forceFlush(): Promise<void> {
+    this.flushCalled = true;
+    return Promise.resolve();
+  }
+}
+
+describe("resolveRedaction", () => {
+  test("true returns default policy", () => {
+    expect(resolveRedaction(true)).toBeInstanceOf(RegexRedactionPolicy);
+  });
+
+  test("false returns undefined", () => {
+    expect(resolveRedaction(false)).toBeUndefined();
+  });
+
+  test("policy passthrough", () => {
+    const policy = new RegexRedactionPolicy();
+    expect(resolveRedaction(policy)).toBe(policy);
+  });
+
+  test("callback wrapped", () => {
+    const resolved = resolveRedaction((_key, value) => value);
+    expect(resolved).toBeInstanceOf(CallbackRedactionPolicy);
+  });
+
+  test("invalid raises type error", () => {
+    expect(() =>
+      resolveRedaction(123 as unknown as boolean),
+    ).toThrow(TypeError);
+  });
+});
+
+describe("redactSpan", () => {
+  test("attributes redacted", () => {
+    const redacted = redactSpan(
+      makeSpan({
+        "gen_ai.input.messages": "secret",
+        "gen_ai.request.model": "mistral-large",
+      }),
+      new AttributeRedactionPolicy(),
+    );
+    expect(redacted.attributes["gen_ai.input.messages"]).toBe(
+      DEFAULT_REDACTED_VALUE,
+    );
+    expect(redacted.attributes["gen_ai.request.model"]).toBe("mistral-large");
+  });
+
+  test("event attributes redacted", () => {
+    const redacted = redactSpan(makeSpan(), new AttributeRedactionPolicy());
+    const event = redacted.events[0]!;
+    expect(event.name).toBe("exception");
+    expect(event.attributes?.["exception.message"]).toBe(DEFAULT_REDACTED_VALUE);
+  });
+
+  test("event untouched fields survive own-key enumeration and spread", () => {
+    // Events are cloned the same way as the span, so fields the redaction does
+    // not touch (name, time, ...) must remain own keys.
+    const events = [
+      { name: "exception", time: 456, attributes: { "exception.message": "boom" } },
+    ] as unknown as ReadableSpanLike["events"];
+    const redacted = redactSpan(
+      makeSpan({}, { events }),
+      new AttributeRedactionPolicy(),
+    );
+    const event = redacted.events[0]! as ReadableSpanLike["events"][number] & {
+      time: number;
+    };
+
+    const spread = { ...event };
+    expect(spread.name).toBe("exception");
+    expect(spread.time).toBe(456);
+    expect(spread.attributes?.["exception.message"]).toBe(DEFAULT_REDACTED_VALUE);
+  });
+
+  test("link attributes redacted", () => {
+    const redacted = redactSpan(makeSpan(), new AttributeRedactionPolicy());
+    expect(redacted.links[0]!.attributes?.["gen_ai.input.messages"]).toBe(
+      DEFAULT_REDACTED_VALUE,
+    );
+  });
+
+  test("resource attributes redacted", () => {
+    const redacted = redactSpan(
+      makeSpan(),
+      new CallbackRedactionPolicy(() => "[MASKED]"),
+    );
+    expect(redacted.resource.attributes["service.name"]).toBe("[MASKED]");
+  });
+
+  test("resource with getter-only attributes redacted", () => {
+    // OpenTelemetry's ResourceImpl exposes `attributes` as a getter-only
+    // accessor; plain assignment on a prototype-based wrapper throws.
+    const resource = Object.create(
+      {},
+      {
+        attributes: {
+          get: () => ({ "service.name": "svc" }),
+          enumerable: true,
+          configurable: true,
+        },
+      },
+    ) as ReadableSpanLike["resource"];
+    const redacted = redactSpan(
+      makeSpan({}, { resource }),
+      new CallbackRedactionPolicy(() => "[MASKED]"),
+    );
+    expect(redacted.resource.attributes["service.name"]).toBe("[MASKED]");
+  });
+
+  test("status description redacted", () => {
+    const redacted = redactSpan(makeSpan(), new AttributeRedactionPolicy());
+    expect(redacted.status.code).toBe(2);
+    expect(redacted.status.message).toBe(DEFAULT_REDACTED_VALUE);
+  });
+
+  test("identity and untouched fields preserved", () => {
+    const original = makeSpan();
+    const redacted = redactSpan(original, new AttributeRedactionPolicy());
+    expect(redacted.spanContext()).toEqual(original.spanContext());
+    // Fields the policy does not touch are cloned as own properties.
+    expect((redacted as FakeSpan).startTime).toBe(123);
+    expect((redacted as FakeSpan).kind).toBe(3);
+  });
+
+  test("untouched fields survive own-key enumeration and spread", () => {
+    // Exporters that spread or enumerate the span (e.g. {...span},
+    // Object.keys) must still see fields the redaction never touched. The
+    // clone copies every own property, so these fields are own keys, not
+    // prototype-only accessors.
+    const original = makeSpan({ "gen_ai.input.messages": "secret" });
+    const redacted = redactSpan(original, new AttributeRedactionPolicy());
+
+    const keys = Object.keys(redacted);
+    expect(keys).toContain("startTime");
+    expect(keys).toContain("kind");
+    expect(keys).toContain("attributes");
+
+    const spread = { ...(redacted as FakeSpan) };
+    expect(spread.startTime).toBe(123);
+    expect(spread.kind).toBe(3);
+    expect(spread.attributes["gen_ai.input.messages"]).toBe(
+      DEFAULT_REDACTED_VALUE,
+    );
+  });
+});
+
+describe("RedactingSpanExporter", () => {
+  test("wrapped exporter receives redacted spans (default policy)", () => {
+    const wrapped = new InMemorySpanExporter();
+    const exporter = new RedactingSpanExporter(wrapped);
+    const span = makeSpan({
+      "gen_ai.output.messages": "leak Bearer abc.def-ghi",
+      "gen_ai.request.model": "mistral-large",
+    });
+
+    exporter.export([span], () => undefined);
+
+    expect(wrapped.spans).toHaveLength(1);
+    const attrs = wrapped.spans[0]!.attributes;
+    expect(attrs["gen_ai.output.messages"]).toBe(
+      `leak ${DEFAULT_REDACTED_VALUE}`,
+    );
+    expect(attrs["gen_ai.request.model"]).toBe("mistral-large");
+  });
+
+  test("custom policy used", () => {
+    const wrapped = new InMemorySpanExporter();
+    const exporter = new RedactingSpanExporter(
+      wrapped,
+      new AttributeRedactionPolicy(),
+    );
+    const span = makeSpan({
+      "gen_ai.output.messages": "leak Bearer abc.def-ghi",
+    });
+
+    exporter.export([span], () => undefined);
+
+    expect(wrapped.spans[0]!.attributes["gen_ai.output.messages"]).toBe(
+      DEFAULT_REDACTED_VALUE,
+    );
+  });
+
+  test("propagates the export result callback", () => {
+    const wrapped = new InMemorySpanExporter();
+    const exporter = new RedactingSpanExporter(wrapped);
+    const results: ExportResultLike[] = [];
+
+    exporter.export([makeSpan()], (result) => results.push(result));
+
+    expect(results).toEqual([{ code: 0 }]);
+  });
+
+  test("shutdown and forceFlush pass through", async () => {
+    const wrapped = new InMemorySpanExporter();
+    const exporter = new RedactingSpanExporter(wrapped);
+
+    await exporter.forceFlush();
+    await exporter.shutdown();
+
+    expect(wrapped.flushCalled).toBe(true);
+    expect(wrapped.shutdownCalled).toBe(true);
+  });
+});

--- a/tests/extra/observability/telemetry.test.ts
+++ b/tests/extra/observability/telemetry.test.ts
@@ -9,7 +9,9 @@ import {
 import { Mistral } from "../../../src/index.js";
 import {
   getTelemetryTracer,
+  RedactingSpanExporter,
   registerTracerProvider,
+  RegexRedactionPolicy,
 } from "../../../src/extra/observability/index.js";
 import {
   configureTelemetry,
@@ -18,6 +20,7 @@ import {
   MISTRAL_SDK_TELEMETRY_ENV,
   MISTRAL_TELEMETRY_ENDPOINT,
   setTracerProvider,
+  shutdownTelemetry,
   TelemetryConfigurationError,
   _createTelemetryTracerProvider,
 } from "../../../src/extra/observability/telemetry.js";
@@ -360,6 +363,40 @@ describe("configureTelemetry", () => {
 
 });
 
+describe("shutdownTelemetry", () => {
+  test("flushes and shuts down the SDK-owned dedicated provider", async () => {
+    const client = createClient();
+    const hook = getTestTracingHook(client);
+    const provider = createProvider();
+    hook.tracerProvider = provider;
+    hook._autoTelemetryProvider = provider;
+
+    await shutdownTelemetry(client);
+
+    expect(provider.shutdownCalled).toBe(true);
+    expect(hook._autoTelemetryProvider).toBeUndefined();
+    expect(hook.tracerProvider).toBeUndefined();
+  });
+
+  test("does not shut down an application-owned custom provider", async () => {
+    const client = createClient();
+    const hook = getTestTracingHook(client);
+    const customProvider = createProvider();
+    hook.tracerProvider = customProvider;
+
+    await shutdownTelemetry(client);
+
+    expect(customProvider.shutdownCalled).toBe(false);
+    expect(hook.tracerProvider).toBe(customProvider);
+  });
+
+  test("is a no-op when no provider is configured", async () => {
+    const client = createClient();
+
+    await expect(shutdownTelemetry(client)).resolves.toBeUndefined();
+  });
+});
+
 describe("getTelemetryTracer", () => {
   test("uses the provider configured on the client", async () => {
     const client = createClient();
@@ -511,5 +548,109 @@ describe("_createTelemetryTracerProvider", () => {
         });
       },
     );
+  });
+
+  test("wraps the exporter with redaction by default", async () => {
+    const exporterInstances: Array<{ config: unknown }> = [];
+    const moduleLoader = createTelemetryModuleLoader(exporterInstances);
+
+    const provider = await _createTelemetryTracerProvider({
+      apiKey: "test-key",
+      moduleLoader,
+    });
+
+    const processor = (provider as unknown as {
+      spanProcessors: Array<{ exporter: unknown }>;
+    }).spanProcessors[0];
+    expect(processor?.exporter).toBeInstanceOf(RedactingSpanExporter);
+  });
+
+  test("redaction=false exports without wrapping", async () => {
+    const exporterInstances: Array<{ config: unknown }> = [];
+    const moduleLoader = createTelemetryModuleLoader(exporterInstances);
+
+    const provider = await _createTelemetryTracerProvider({
+      apiKey: "test-key",
+      moduleLoader,
+      redaction: false,
+    });
+
+    const processor = (provider as unknown as {
+      spanProcessors: Array<{ exporter: unknown }>;
+    }).spanProcessors[0];
+    expect(processor?.exporter).toBe(exporterInstances[0]);
+    expect(processor?.exporter).not.toBeInstanceOf(RedactingSpanExporter);
+  });
+
+  test("accepts a custom redaction policy", async () => {
+    const exporterInstances: Array<{ config: unknown }> = [];
+    const moduleLoader = createTelemetryModuleLoader(exporterInstances);
+
+    const provider = await _createTelemetryTracerProvider({
+      apiKey: "test-key",
+      moduleLoader,
+      redaction: new RegexRedactionPolicy(),
+    });
+
+    const processor = (provider as unknown as {
+      spanProcessors: Array<{ exporter: unknown }>;
+    }).spanProcessors[0];
+    expect(processor?.exporter).toBeInstanceOf(RedactingSpanExporter);
+  });
+});
+
+describe("configureTelemetry redaction warnings", () => {
+  test("warns when redaction is passed in global mode", async () => {
+    const client = createClient();
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+
+    await configureTelemetry(client, "global", { redaction: true });
+
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+  });
+
+  test("warns when redaction is passed with a custom provider", async () => {
+    const client = createClient();
+    const provider = createProvider();
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+
+    await configureTelemetry(client, provider, {
+      redaction: new RegexRedactionPolicy(),
+    });
+
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+  });
+
+  test("does not warn when redaction is disabled in global mode", async () => {
+    const client = createClient();
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+
+    await configureTelemetry(client, "global", { redaction: false });
+
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  test("warns in global mode when redaction is omitted (on by default)", async () => {
+    const client = createClient();
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+
+    await configureTelemetry(client, "global");
+
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+  });
+
+  test("does not warn in env-driven global auto-config", async () => {
+    await withEnv({ [MISTRAL_SDK_TELEMETRY_ENV]: "global" }, async () => {
+      const hook = new TracingHook();
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+
+      const configured = await configureTelemetryForHook(hook, createContext(), {
+        respectGlobalProvider: true,
+      });
+
+      expect(configured).toBe(true);
+      expect(hook._telemetryUseGlobalProvider).toBe(true);
+      expect(warnSpy).not.toHaveBeenCalled();
+    });
   });
 });


### PR DESCRIPTION
## What

Adds client-side redaction of OpenTelemetry spans emitted by the SDK, so PII and secrets are stripped before spans leave the process.

### New public API (`@mistralai/mistralai/extra/observability`)

- **`RedactingSpanExporter`** — wraps any OTEL `SpanExporter` and redacts span attributes, events, links, and resource attributes before delegating export. Reusable by any OpenTelemetry application, independent of the Mistral client.
- **Redaction policies**, each exported with its defaults as constants so they can be extended rather than replaced:
  - `RegexRedactionPolicy` (default) — content-oriented: keeps keys/structure, redacts matched substrings (secret tokens plus PII: emails, card-like sequences, IPv4).
  - `AttributeRedactionPolicy` — key-oriented: redacts whole values for sensitive keys, then scans kept values for secret tokens.
  - `CallbackRedactionPolicy` — a `(key, value) => value | undefined` masker for full control (can drop attributes entirely).
- **`configureTelemetry(client, provider?, options?)`** gains a `redaction` option:
  - Dedicated mode (SDK owns the exporter): redaction is **on by default**; pass `false`, a policy instance, or a callback to customize.
  - Global / custom-provider modes: the application owns the export pipeline, so the option is ignored and a warning is logged. Wrap your own exporter with `RedactingSpanExporter` to redact there.
- **`shutdownTelemetry(client)`** — flushes and shuts down the SDK-owned provider so short-lived programs export buffered spans before exiting.

### Other changes

- OpenTelemetry SDK / exporter / resources declared as **optional peer dependencies**.
- Lazy OTel import marked bundler-ignore (webpack / Turbopack / Vite) so the SDK works when bundled as first-party source.
- README "Telemetry & Observability" section (provider modes, redaction policies, env vars) + TOC entry.
- Runnable examples under `examples/src/observability/` (dedicated mode, global provider with redaction, custom/extended policies).

## Usage

```typescript
import { Mistral } from "@mistralai/mistralai";
import { configureTelemetry, shutdownTelemetry } from "@mistralai/mistralai/extra/observability";

const client = new Mistral({ apiKey: process.env["MISTRAL_API_KEY"] });

// Dedicated mode is the default; redaction is on by default.
await configureTelemetry(client);

// ... make requests ...

await shutdownTelemetry(client);
```

## Testing

- `npm run build` — clean
- `npm run lint` — 0 warnings / 0 errors
- `tests/` — 174/174 pass (new: 18 redaction, 47 policy, +11 telemetry)