### PR TITLE
examples: fix chat_with_image using a dead image URL

### DIFF
--- a/examples/src/async_chat_with_image_no_streaming.ts
+++ b/examples/src/async_chat_with_image_no_streaming.ts
@@ -17,7 +17,7 @@ const chatResponse = await client.chat.complete({
         {
           type: "image_url",
           imageUrl:
-            "https://mistral.ai/_astro/ai-app_Z2q9iqE.webp?dpl=6a57bb9ad483ec680851599b",
+            "https://raw.githubusercontent.com/mistralai/mistral-common/7edf6f651b3579135f44686e345d51b7e19a536a/docs/assets/logo_favicon.png",
         },
       ],
     },

--- a/examples/src/async_chat_with_image_no_streaming.ts
+++ b/examples/src/async_chat_with_image_no_streaming.ts
@@ -17,7 +17,7 @@ const chatResponse = await client.chat.complete({
         {
           type: "image_url",
           imageUrl:
-            "https://cms.mistral.ai/assets/ce1514ab-62f9-4825-a20b-298f2497c536",
+            "https://mistral.ai/_astro/ai-app_Z2q9iqE.webp?dpl=6a57bb9ad483ec680851599b",
         },
       ],
     },


### PR DESCRIPTION
`async_chat_with_image_no_streaming.ts` pointed at a deleted asset, so the API returned 400 invalid_request_file. Use a live image. Verified the example runs against the API.