### PR TITLE
feat(observability): add flushTelemetry to drain spans without shutdown

### DIFF
--- a/src/extra/observability/index.ts
+++ b/src/extra/observability/index.ts
@@ -4,6 +4,7 @@ export { getRegisteredTracerProvider, registerTracerProvider } from "./provider.
 export {
   configureTelemetry,
   configureTelemetryForHook,
+  flushTelemetry,
   getTelemetryTracer,
   MISTRAL_OTLP_TRACES_ENDPOINT_ENV,
   MISTRAL_SDK_TELEMETRY_ENV,

--- a/src/extra/observability/telemetry.ts
+++ b/src/extra/observability/telemetry.ts
@@ -154,6 +154,19 @@ export async function setTracerProvider(
 }
 
 /**
+ * Flush the SDK-owned telemetry provider attached to `client` without shutting
+ * it down or detaching it.
+ *
+ * This is a no-op when dedicated telemetry is not configured. In global/custom
+ * provider modes the application owns the provider lifecycle. Rejections from
+ * the SDK-owned provider's `forceFlush()` are propagated to the caller.
+ */
+export async function flushTelemetry(client: ClientWithHooks): Promise<void> {
+  const hook = getTracingHook(client);
+  await hook._autoTelemetryProvider?.forceFlush?.();
+}
+
+/**
  * Flush and shut down the SDK-owned telemetry provider attached to `client`.
  *
  * In dedicated mode the SDK owns a BatchSpanProcessor that buffers spans and

--- a/tests/extra/observability/telemetry.test.ts
+++ b/tests/extra/observability/telemetry.test.ts
@@ -16,6 +16,7 @@ import {
 import {
   configureTelemetry,
   configureTelemetryForHook,
+  flushTelemetry,
   MISTRAL_OTLP_TRACES_ENDPOINT_ENV,
   MISTRAL_SDK_TELEMETRY_ENV,
   MISTRAL_TELEMETRY_ENDPOINT,
@@ -28,7 +29,9 @@ import { TracingHook } from "../../../src/hooks/tracing.js";
 import type { HookContext } from "../../../src/hooks/types.js";
 
 type FakeProvider = TracerProvider & {
+  forceFlushCalled: number;
   shutdownCalled: boolean;
+  forceFlush: () => void | Promise<void>;
   shutdown: () => void;
 };
 
@@ -53,15 +56,53 @@ function createSpan(): Span {
 
 function createProvider(): FakeProvider {
   const provider = {
+    forceFlushCalled: 0,
     shutdownCalled: false,
     getTracer: () => ({
       startSpan: () => createSpan(),
       startActiveSpan: () => undefined as never,
     }),
+    forceFlush() {
+      provider.forceFlushCalled += 1;
+    },
     shutdown() {
       provider.shutdownCalled = true;
     },
   } as FakeProvider;
+  return provider;
+}
+
+function createBatchingProvider(): FakeProvider & { exportedSpans: string[] } {
+  const pendingSpans: string[] = [];
+  const exportedSpans: string[] = [];
+  const tracer = {
+    startSpan(name: string) {
+      const span = createSpan();
+      let ended = false;
+      span.end = () => {
+        if (!ended) {
+          pendingSpans.push(name);
+          ended = true;
+        }
+      };
+      return span;
+    },
+    startActiveSpan: () => undefined as never,
+  } as Tracer;
+
+  const provider = {
+    forceFlushCalled: 0,
+    shutdownCalled: false,
+    exportedSpans,
+    getTracer: () => tracer,
+    forceFlush() {
+      provider.forceFlushCalled += 1;
+      exportedSpans.push(...pendingSpans.splice(0));
+    },
+    shutdown() {
+      provider.shutdownCalled = true;
+    },
+  } as FakeProvider & { exportedSpans: string[] };
   return provider;
 }
 
@@ -394,6 +435,80 @@ describe("shutdownTelemetry", () => {
     const client = createClient();
 
     await expect(shutdownTelemetry(client)).resolves.toBeUndefined();
+  });
+});
+
+describe("flushTelemetry", () => {
+  test("flushes the SDK-owned provider without shutting it down or detaching it", async () => {
+    const client = createClient();
+    const hook = getTestTracingHook(client);
+    const provider = createProvider();
+    hook.tracerProvider = provider;
+    hook._autoTelemetryProvider = provider;
+
+    await flushTelemetry(client);
+
+    expect(provider.forceFlushCalled).toBe(1);
+    expect(provider.shutdownCalled).toBe(false);
+    expect(hook._autoTelemetryProvider).toBe(provider);
+    expect(hook.tracerProvider).toBe(provider);
+  });
+
+  test("exports spans created after an earlier flush", async () => {
+    const client = createClient();
+    const hook = getTestTracingHook(client);
+    const provider = createBatchingProvider();
+    hook.tracerProvider = provider;
+    hook._autoTelemetryProvider = provider;
+    const tracer = getTelemetryTracer(client, "flush-test");
+
+    tracer.startSpan("first").end();
+    await flushTelemetry(client);
+    expect(provider.exportedSpans).toEqual(["first"]);
+
+    tracer.startSpan("second").end();
+    await flushTelemetry(client);
+
+    expect(provider.exportedSpans).toEqual(["first", "second"]);
+    expect(provider.forceFlushCalled).toBe(2);
+    expect(provider.shutdownCalled).toBe(false);
+  });
+
+  test("does not flush an application-owned custom provider", async () => {
+    const client = createClient();
+    const hook = getTestTracingHook(client);
+    const customProvider = createProvider();
+    hook.tracerProvider = customProvider;
+
+    await flushTelemetry(client);
+
+    expect(customProvider.forceFlushCalled).toBe(0);
+    expect(customProvider.shutdownCalled).toBe(false);
+    expect(hook.tracerProvider).toBe(customProvider);
+  });
+
+  test("is a no-op when no provider is configured", async () => {
+    const client = createClient();
+
+    await expect(flushTelemetry(client)).resolves.toBeUndefined();
+  });
+
+  test("propagates forceFlush rejections without detaching the provider", async () => {
+    const client = createClient();
+    const hook = getTestTracingHook(client);
+    const provider = createProvider();
+    const failure = new Error("export failed");
+    provider.forceFlush = async () => {
+      throw failure;
+    };
+    hook.tracerProvider = provider;
+    hook._autoTelemetryProvider = provider;
+
+    await expect(flushTelemetry(client)).rejects.toBe(failure);
+
+    expect(provider.shutdownCalled).toBe(false);
+    expect(hook._autoTelemetryProvider).toBe(provider);
+    expect(hook.tracerProvider).toBe(provider);
   });
 });
 


### PR DESCRIPTION
## Summary

- Adds `flushTelemetry(client)` as a complement to `shutdownTelemetry(client)`
- Calls `forceFlush()` on the SDK-owned `BatchSpanProcessor`, exporting all buffered spans, then leaves the provider alive for subsequent requests
- Exports `flushTelemetry` from the public `extra/observability` entry point

## Motivation (OBS-2120 / OBS-2121)

The `BatchSpanProcessor` buffers spans and only exports them on a timer or on explicit flush/shutdown. In short-lived or serverless runtimes (e.g. Next.js on Vercel), the process is **frozen** after sending the response — the timer never fires and buffered spans are silently dropped.

The reliable workaround is to call `shutdownTelemetry` in a `finally` block after each request, which forces a flush before the provider is torn down. This works, but it requires creating and configuring a new client and provider on every request.

`flushTelemetry` drains the buffer without closing the provider, enabling a singleton client that is configured once and reused across warm requests — trading per-request provider setup/teardown for a single `forceFlush()` call.

Ported from mistralai/client-ts-private#345.

## Test plan

- [ ] Unit tests cover: flush without shutdown, spans created after flush are exported on next flush, no-op on custom/missing provider, rejection propagation without provider detach
- [ ] End-to-end verified against the Observability API on the private SDK: unflushed trace absent (bug confirmed), flushed trace present (fix confirmed), shutdown control trace present

🤖 Generated with [Claude Code](https://claude.com/claude-code)