### PR TITLE
chore: bump Speakeasy to 1.796.1 (on hold)

### DIFF
--- a/.speakeasy/workflow.yaml
+++ b/.speakeasy/workflow.yaml
@@ -1,5 +1,5 @@
 workflowVersion: 1.0.0
-speakeasyVersion: 1.763.6
+speakeasyVersion: 1.796.1
 sources:
     mistral-azure-source:
         inputs:


### PR DESCRIPTION
On hold.

Generating at `1.796.1` collapses the discriminated overloads on `audio.speech.complete`. Today the streaming and non-streaming forms return distinct types; at `1.796.1` all overloads resolve to the union, so callers lose narrowing and `res.audioData` and `for await` stop type checking. Runtime behaviour is unchanged, but it is a breaking change to the published TypeScript contract.

The generator fix that motivated the Python bump is Python only, so there is no upside here to offset that.

Holding until the overload behaviour is resolved upstream.
