### PR TITLE
chore: bump Speakeasy to 1.796.4

### DIFF
--- a/.speakeasy/workflow.yaml
+++ b/.speakeasy/workflow.yaml
@@ -1,5 +1,5 @@
 workflowVersion: 1.0.0
-speakeasyVersion: 1.763.6
+speakeasyVersion: 1.796.4
 sources:
     mistral-azure-source:
         inputs:


### PR DESCRIPTION
Bumps the generator pin from `1.763.6`.

`1.769.0` collapsed the SSE overload return types for operations that also declare an error response, so `audio.speech.complete` lost its narrowing. `1.796.4` restores it, verified by regenerating and type checking a caller that uses both the streaming and non-streaming forms.

This supersedes #266, which was held for that reason.

Pin only, no generated output.